### PR TITLE
Validation & tests (+readme update)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,70 +1,113 @@
 # Pomodoro Web
 
-A web-based Pomodoro timer that runs in your browser tab to help you stay focused and productive.
+Pomodoro Web is a static browser-based focus app with a persistent 4-session Pomodoro timer, a mini timer for secondary pages, and a local-only productivity workspace for tasks and notes.
 
-## What is the Pomodoro Technique?
-The Pomodoro Technique is a time‑management method that splits work into focused sessions (Pomodoros) followed by short breaks.  
-It’s more effective than a basic timer because it builds rest into the workflow, reduces burnout, and keeps your focus consistent.
+## Product Overview
+- Persistent Pomodoro cycle that survives refreshes, tab switches, and browser restarts by rehydrating state from `localStorage`
+- Full 4-session cycle with Pomodoro, Short Break, and Long Break transitions
+- Mini timer in the header on secondary pages
+- Local productivity page with to-do and notes tabs
+- Optional transition sounds
+- No login, no backend, no sync requirement
 
-## Features
-- Pomodoro, Short Break, and Long Break modes
-- Start / Reset controls
-- Configurable session lengths
-- Optional sound notifications
-- Session counter for longer break tracking
+## Core Behavior
+- Timer state is stored in `localStorage` and recalculated from wall-clock time whenever the timer page is reopened.
+- After the fourth Pomodoro, the app runs the long break and then resets to idle Pomodoro 1.
+- Settings apply only while the timer is idle. Running timers do not get mutated mid-session.
+- Productivity items are stored locally and normalized on load so malformed stored data does not break the UI.
 
-## How to Use
-1. Open the app by following the link: https://docholypancake.github.io/pomodoroWeb/.
-2. Choose your mode (Pomodoro / Short Break / Long Break).
-3. Click **Start** and focus until the timer ends.
-4. Take the suggested break.
-5. Repeat the cycle; after a few sessions, take a longer break.
+## Validation Rules
+### Timer Settings
+- Pomodoro: `1` to `120`
+- Short Break: `1` to `30`
+- Long Break: `1` to `80`
+- `0` resets that specific field to its default value
+- Decimal values are floored: `5.5` becomes `5`
+- Negative values are rejected
+- Scientific and hexadecimal-like input such as `1e2` and `0x10` are rejected
 
-## Please note
-If you use Safari to run our timer, you won't be able to get sound notifications if run in the background, since Safari suspends most background tabs in about 10-15 seconds. Please use Pomodoro Web with Chrome for a better experience!
-
-## Settings
-Click the **Settings** button to customize:
-- Pomodoro duration  
-- Short break duration  
-- Long break duration  
-- Sound notifications  
-
-Changes apply immediately after saving.
+### Productivity Fields
+- Task input is trimmed, required, and capped to `160` characters
+- Note input is trimmed, required, and capped to `1200` characters
+- The same rules apply when items are restored from `localStorage`, not only when entered through the UI
 
 ## Pages
-- Timer: [index.html](index.html)  
-- About: [about.html](about.html)  
-- Help Us: [helpus.html](helpus.html)
+- Timer: `index.html`
+- Productivity: `productivity.html`
+- About: `about.html`
+- Help Us: `helpus.html`
 
-## Project Structure
+## Technical Notes
+- Static HTML/CSS/JS project
+- Shared timer state lives in `js/timer-state.js`
+- Shared settings validation lives in `js/settings-validation.js`
+- Shared productivity storage logic lives in `js/productivity-store.js`
+- Sound playback is coordinated through `js/sound.js`
+- Browser tests use Playwright
+- Unit tests use Vitest with `jsdom`
+
+## Run Locally
+Open the app directly in a browser for quick manual checks, or use the local test server for browser automation.
+
+Install dependencies:
+
+```bash
+npm install
 ```
+
+Run tests:
+
+```bash
+npm run test
+npm run test:unit
+npm run test:e2e
+npm run test:smoke
+npm run test:regression
+```
+
+Quiet mode without per-test `Expected / Actual` output:
+
+```bash
+npm run test:unit:quiet
+npm run test:e2e:quiet
+```
+
+## Test Coverage
+- Unit tests cover timer-state rules, settings validation, and productivity storage normalization
+- Smoke tests cover shell rendering, navigation, and page availability
+- E2E tests cover timer persistence, field validation, mini timer behavior, cross-page sync, and productivity CRUD flows
+- A manual checklist lives in `docs/testing/manual-test-plan.md`
+
+## Repository Structure
+```text
 index.html
+productivity.html
 about.html
 helpus.html
 css/
   style.css
+  modules/
 js/
+  timer-state.js
   timer.js
+  settings-validation.js
   settings.js
-  worker.js
-assets/
-  icon/
-    icon.ico
-  pictures/
-    author.jpg
-  sounds/
-    timer_sound_up.wav
-    timer_dound_down.wav
+  mini-timer.js
+  productivity-store.js
+  productivity.js
+  sound.js
+tests/
+  unit/
+  e2e/
+docs/
+  testing/
 ```
 
-## Run Locally
-You can open [index.html](index.html) directly in your browser.  
-For best results, use a local server (prevents asset loading issues).
+## Browser Note
+Safari can aggressively suspend background tabs, which may interfere with background audio playback even when timer state itself is restored correctly. Chrome-based browsers generally give the best experience for background sound behavior.
 
 ## Contributing
-- Suggest changes or report issues:  
-  https://github.com/docholypancake/pomodoroWeb/issues
+- Report bugs or suggest changes: https://github.com/docholypancake/pomodoroWeb/issues
 
 ## License
-See [LICENSE](LICENSE).
+See `LICENSE`.

--- a/docs/testing/manual-test-plan.md
+++ b/docs/testing/manual-test-plan.md
@@ -35,18 +35,26 @@
 ### Timer Settings Negative Cases
 - Enter `0` in Pomodoro and click `Save & Close`.
   Expected result: the field resets to its default value (`25` for Pomodoro), the value is accepted, and reopening Settings shows the defaulted value.
+- Enter a negative value such as `-4` in Pomodoro and click `Save & Close`.
+  Expected result: save is blocked, `Pomodoro must be between 1 and 120.` is shown, and the field is marked invalid.
 - Enter `121` in Pomodoro and click `Save & Close`.
   Expected result: save is blocked with the same inline validation behavior.
 - Enter `0` or `31` in Short Break and click `Save & Close`.
   Expected result: `0` resets to the default short break value (`5`), while `31` is blocked with `Short break must be between 1 and 30.`.
+- Enter a negative value such as `-4` in Short Break and click `Save & Close`.
+  Expected result: save is blocked, `Short break must be between 1 and 30.` is shown, and the field is marked invalid.
 - Enter `0` or `81` in Long Break and click `Save & Close`.
   Expected result: `0` resets to the default long break value (`15`), while `81` is blocked with `Long break must be between 1 and 80.`.
+- Enter a negative value such as `-4` in Long Break and click `Save & Close`.
+  Expected result: save is blocked, `Long break must be between 1 and 80.` is shown, and the field is marked invalid.
 - Clear a numeric field so it becomes blank, then click `Save & Close`.
   Expected result: save is blocked, the field is marked invalid, and previously saved values are preserved.
 - Enter a decimal such as `5.5` and click `Save & Close`.
   Expected result: the field is floored to `5`, the displayed value changes to `5`, and the save succeeds.
 - Enter non-numeric text through browser devtools/manual DOM edit, then click `Save & Close`.
   Expected result: save is blocked because the field must resolve to a whole number within that field’s allowed range.
+- Enter scientific or non-decimal numeric formats such as `1e2` or `0x10` through browser devtools/manual DOM edit, then click `Save & Close`.
+  Expected result: save is blocked because only regular decimal whole-number input is allowed.
 - Start the timer and attempt to open Settings.
   Expected result: the Settings button stays disabled and the settings panel does not open while the timer is running.
 - Corrupt `pomodoroSettings` in localStorage manually, then reload and open Settings.
@@ -61,6 +69,9 @@
 - Adding, editing, deleting, and completing a todo item updates the UI and persists after reload.
 - Adding, editing, and deleting a note updates the UI and persists after reload.
 - Empty submissions show inline validation feedback.
+- Whitespace-only tasks and notes are rejected for both add and edit flows.
+- Very long tasks and notes are capped to the field maximums (`160` for tasks, `1200` for notes).
+- Invalid seeded productivity entries in localStorage are either trimmed to safe limits or dropped entirely if blank after normalization.
 - Corrupted `pomodoroProductivity.v1` storage falls back to a safe empty state without breaking the page.
 
 ## Responsive / Visual

--- a/index.html
+++ b/index.html
@@ -131,6 +131,7 @@
 
     <script src="js/sound.js"></script>
     <script src="js/timer-state.js"></script>
+    <script src="js/settings-validation.js"></script>
     <script src="js/settings.js"></script>
     <script src="js/timer.js"></script>
 </body>

--- a/js/productivity-store.js
+++ b/js/productivity-store.js
@@ -1,5 +1,9 @@
 (function (globalScope) {
     const STORAGE_KEY = "pomodoroProductivity.v1";
+    const ITEM_LIMITS = {
+        todo: 160,
+        notes: 1200
+    };
 
     function createId() {
         if (globalScope?.crypto?.randomUUID) {
@@ -26,31 +30,112 @@
         };
     }
 
+    function sanitizeTextValue(value, maxLength) {
+        if (typeof value !== "string") return null;
+
+        const trimmedValue = value.trim();
+        if (!trimmedValue) return null;
+
+        return trimmedValue.slice(0, maxLength);
+    }
+
+    function normalizeTodoItem(item, fallbackTimestamp) {
+        const text = sanitizeTextValue(item?.text, ITEM_LIMITS.todo);
+        if (!item || typeof item.id !== "string" || !text) {
+            return null;
+        }
+
+        return {
+            id: item.id,
+            text,
+            completed: Boolean(item.completed),
+            createdAt: isValidTimestamp(item.createdAt) ? item.createdAt : fallbackTimestamp,
+            updatedAt: isValidTimestamp(item.updatedAt) ? item.updatedAt : fallbackTimestamp
+        };
+    }
+
+    function normalizeNoteItem(item, fallbackTimestamp) {
+        const content = sanitizeTextValue(item?.content, ITEM_LIMITS.notes);
+        if (!item || typeof item.id !== "string" || !content) {
+            return null;
+        }
+
+        return {
+            id: item.id,
+            content,
+            createdAt: isValidTimestamp(item.createdAt) ? item.createdAt : fallbackTimestamp,
+            updatedAt: isValidTimestamp(item.updatedAt) ? item.updatedAt : fallbackTimestamp
+        };
+    }
+
+    function sanitizeCreatePayload(type, payload) {
+        if (type === "todo") {
+            const text = sanitizeTextValue(payload?.text, ITEM_LIMITS.todo);
+            if (!text) return null;
+
+            return {
+                text,
+                completed: Boolean(payload?.completed)
+            };
+        }
+
+        if (type === "notes") {
+            const content = sanitizeTextValue(payload?.content, ITEM_LIMITS.notes);
+            if (!content) return null;
+
+            return { content };
+        }
+
+        return null;
+    }
+
+    function sanitizeUpdateChanges(type, changes) {
+        if (!changes || typeof changes !== "object") return null;
+
+        if (type === "todo") {
+            const nextChanges = {};
+
+            if (Object.prototype.hasOwnProperty.call(changes, "text")) {
+                const text = sanitizeTextValue(changes.text, ITEM_LIMITS.todo);
+                if (!text) return null;
+                nextChanges.text = text;
+            }
+
+            if (Object.prototype.hasOwnProperty.call(changes, "completed")) {
+                nextChanges.completed = Boolean(changes.completed);
+            }
+
+            return Object.keys(nextChanges).length ? nextChanges : null;
+        }
+
+        if (type === "notes") {
+            if (!Object.prototype.hasOwnProperty.call(changes, "content")) {
+                return null;
+            }
+
+            const content = sanitizeTextValue(changes.content, ITEM_LIMITS.notes);
+            if (!content) return null;
+
+            return { content };
+        }
+
+        return null;
+    }
+
     function normalizeProductivityState(rawState, nowProvider = () => new Date()) {
         const fallbackTimestamp = getIsoNow(nowProvider);
         const safeState = emptyState();
 
         safeState.todo = Array.isArray(rawState?.todo)
             ? rawState.todo
-                .filter(item => item && typeof item.id === "string" && typeof item.text === "string")
-                .map(item => ({
-                    id: item.id,
-                    text: item.text,
-                    completed: Boolean(item.completed),
-                    createdAt: isValidTimestamp(item.createdAt) ? item.createdAt : fallbackTimestamp,
-                    updatedAt: isValidTimestamp(item.updatedAt) ? item.updatedAt : fallbackTimestamp
-                }))
+                .map(item => normalizeTodoItem(item, fallbackTimestamp))
+                .filter(Boolean)
             : [];
 
         safeState.notes = Array.isArray(rawState?.notes)
             ? rawState.notes
-                .filter(item => item && typeof item.id === "string" && typeof item.content === "string")
-                .map(item => ({
-                    id: item.id,
-                    content: item.content,
-                    createdAt: isValidTimestamp(item.createdAt) ? item.createdAt : fallbackTimestamp,
-                    updatedAt: isValidTimestamp(item.updatedAt) ? item.updatedAt : fallbackTimestamp
-                }))
+                .map(item => normalizeNoteItem(item, fallbackTimestamp))
+                .filter(Boolean)
             : [];
 
         return safeState;
@@ -86,12 +171,17 @@
             },
             create(type, payload) {
                 const state = this.load();
+                const sanitizedPayload = sanitizeCreatePayload(type, payload);
+                if (!sanitizedPayload || !Array.isArray(state[type])) {
+                    return state[type] || [];
+                }
+
                 const now = getIsoNow(nowProvider);
                 const nextItem = {
                     id: idFactory(),
                     createdAt: now,
                     updatedAt: now,
-                    ...payload
+                    ...sanitizedPayload
                 };
 
                 state[type] = [nextItem, ...state[type]];
@@ -99,12 +189,17 @@
             },
             update(type, itemId, changes) {
                 const state = this.load();
+                const sanitizedChanges = sanitizeUpdateChanges(type, changes);
+                if (!sanitizedChanges || !Array.isArray(state[type])) {
+                    return state[type] || [];
+                }
+
                 state[type] = state[type].map(item => {
                     if (item.id !== itemId) return item;
 
                     return {
                         ...item,
-                        ...changes,
+                        ...sanitizedChanges,
                         updatedAt: getIsoNow(nowProvider)
                     };
                 });
@@ -121,9 +216,11 @@
 
     const api = {
         STORAGE_KEY,
+        ITEM_LIMITS,
         createId,
         isValidTimestamp,
         emptyState,
+        sanitizeTextValue,
         normalizeProductivityState,
         createProductivityStore
     };

--- a/js/productivity.js
+++ b/js/productivity.js
@@ -157,6 +157,7 @@ document.addEventListener("DOMContentLoaded", () => {
                         <button class="productivity-action productivity-action--primary" type="button" data-action="save-edit">Save</button>
                         <button class="productivity-action" type="button" data-action="cancel-edit">Cancel</button>
                     </div>
+                    <p class="form-message hidden productivity-item__message" data-edit-message="todo" aria-live="polite"></p>
                 </li>
             `;
         }
@@ -199,6 +200,7 @@ document.addEventListener("DOMContentLoaded", () => {
                         <button class="productivity-action productivity-action--primary" type="button" data-action="save-edit">Save</button>
                         <button class="productivity-action" type="button" data-action="cancel-edit">Cancel</button>
                     </div>
+                    <p class="form-message hidden productivity-item__message" data-edit-message="notes" aria-live="polite"></p>
                 </li>
             `;
         }
@@ -290,14 +292,25 @@ document.addEventListener("DOMContentLoaded", () => {
         const type = itemElement.dataset.itemType;
         const itemId = itemElement.dataset.itemId;
         const editor = itemElement.querySelector(`[data-edit-field="${type}"]`);
+        const messageElement = itemElement.querySelector(`[data-edit-message="${type}"]`);
         const nextValue = editor?.value.trim() || "";
 
         markInvalid(editor, false);
+        if (messageElement) {
+            messageElement.textContent = "";
+            messageElement.classList.add("hidden");
+            messageElement.classList.remove("form-message--error");
+        }
 
         if (!type || !itemId || !editor) return;
 
         if (!nextValue) {
             markInvalid(editor, true);
+            if (messageElement) {
+                messageElement.textContent = `Please enter a ${itemLabels[type]} before saving it.`;
+                messageElement.classList.remove("hidden");
+                messageElement.classList.add("form-message--error");
+            }
             editor.focus();
             return;
         }

--- a/js/settings-validation.js
+++ b/js/settings-validation.js
@@ -1,0 +1,139 @@
+(function (globalScope) {
+    const DEFAULT_SETTINGS = {
+        pomodoro: 25,
+        shortBreak: 5,
+        longBreak: 15,
+        soundEnabled: true
+    };
+
+    const FIELD_LIMITS = {
+        pomodoro: {
+            key: "pomodoro",
+            label: "Pomodoro",
+            min: 1,
+            max: 120
+        },
+        shortBreak: {
+            key: "shortBreak",
+            label: "Short break",
+            min: 1,
+            max: 30
+        },
+        longBreak: {
+            key: "longBreak",
+            label: "Long break",
+            min: 1,
+            max: 80
+        }
+    };
+
+    function buildFieldConfig(defaultSettings = DEFAULT_SETTINGS) {
+        return Object.values(FIELD_LIMITS).map(field => ({
+            ...field,
+            defaultValue: Number(defaultSettings?.[field.key]) || DEFAULT_SETTINGS[field.key]
+        }));
+    }
+
+    function normalizeMinuteValue(rawValue, config) {
+        const trimmedValue = String(rawValue ?? "").trim();
+
+        if (trimmedValue === "") {
+            return {
+                value: null,
+                isValid: false,
+                displayValue: "",
+                reason: "blank"
+            };
+        }
+
+        const numericValue = Number(trimmedValue);
+        if (!Number.isFinite(numericValue)) {
+            return {
+                value: null,
+                isValid: false,
+                displayValue: trimmedValue,
+                reason: "non-numeric"
+            };
+        }
+
+        const flooredValue = Math.floor(numericValue);
+
+        if (flooredValue < config.min) {
+            return {
+                value: config.defaultValue,
+                isValid: true,
+                displayValue: String(config.defaultValue),
+                reason: "below-min-defaulted"
+            };
+        }
+
+        if (flooredValue > config.max) {
+            return {
+                value: flooredValue,
+                isValid: false,
+                displayValue: String(flooredValue),
+                reason: "above-max"
+            };
+        }
+
+        return {
+            value: flooredValue,
+            isValid: true,
+            displayValue: String(flooredValue),
+            reason: Number.isInteger(numericValue) ? "valid" : "floored"
+        };
+    }
+
+    function validateSettingsDraftValues(rawValues, fieldConfigs, normalizeSettings = value => value) {
+        const draft = {
+            soundEnabled: rawValues?.soundEnabled !== false
+        };
+        const fieldResults = {};
+
+        for (const config of fieldConfigs) {
+            const normalizedField = normalizeMinuteValue(rawValues?.[config.key], config);
+            fieldResults[config.key] = normalizedField;
+
+            if (
+                !normalizedField.isValid
+                || !Number.isInteger(normalizedField.value)
+                || normalizedField.value < config.min
+                || normalizedField.value > config.max
+            ) {
+                return {
+                    isValid: false,
+                    draft: null,
+                    invalidKey: config.key,
+                    message: `${config.label} must be between ${config.min} and ${config.max}.`,
+                    fieldResults
+                };
+            }
+
+            draft[config.key] = normalizedField.value;
+        }
+
+        return {
+            isValid: true,
+            draft: normalizeSettings(draft),
+            invalidKey: null,
+            message: "",
+            fieldResults
+        };
+    }
+
+    const api = {
+        DEFAULT_SETTINGS,
+        FIELD_LIMITS,
+        buildFieldConfig,
+        normalizeMinuteValue,
+        validateSettingsDraftValues
+    };
+
+    if (globalScope) {
+        globalScope.PomodoroSettingsValidation = api;
+    }
+
+    if (typeof module !== "undefined" && module.exports) {
+        module.exports = api;
+    }
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js/settings-validation.js
+++ b/js/settings-validation.js
@@ -26,6 +26,7 @@
             max: 80
         }
     };
+    const DECIMAL_MINUTES_PATTERN = /^\d+(?:\.\d+)?$/;
 
     function buildFieldConfig(defaultSettings = DEFAULT_SETTINGS) {
         return Object.values(FIELD_LIMITS).map(field => ({
@@ -46,24 +47,33 @@
             };
         }
 
-        const numericValue = Number(trimmedValue);
-        if (!Number.isFinite(numericValue)) {
+        if (!DECIMAL_MINUTES_PATTERN.test(trimmedValue)) {
             return {
                 value: null,
                 isValid: false,
                 displayValue: trimmedValue,
-                reason: "non-numeric"
+                reason: "invalid-format"
             };
         }
 
+        const numericValue = Number(trimmedValue);
         const flooredValue = Math.floor(numericValue);
 
-        if (flooredValue < config.min) {
+        if (flooredValue === 0) {
             return {
                 value: config.defaultValue,
                 isValid: true,
                 displayValue: String(config.defaultValue),
                 reason: "below-min-defaulted"
+            };
+        }
+
+        if (flooredValue < config.min) {
+            return {
+                value: flooredValue,
+                isValid: false,
+                displayValue: String(flooredValue),
+                reason: "below-min"
             };
         }
 
@@ -124,6 +134,7 @@
     const api = {
         DEFAULT_SETTINGS,
         FIELD_LIMITS,
+        DECIMAL_MINUTES_PATTERN,
         buildFieldConfig,
         normalizeMinuteValue,
         validateSettingsDraftValues

--- a/js/settings.js
+++ b/js/settings.js
@@ -11,6 +11,7 @@ const soundEnabledInput = document.getElementById("soundEnabled");
 const settingsError = document.getElementById("settingsError");
 
 const timerStateStore = window.PomodoroTimerState;
+const settingsValidationApi = window.PomodoroSettingsValidation;
 const defaultSettings = timerStateStore ? timerStateStore.getDefaultSettings() : {
     pomodoro: 25,
     shortBreak: 5,
@@ -18,11 +19,22 @@ const defaultSettings = timerStateStore ? timerStateStore.getDefaultSettings() :
     soundEnabled: true
 };
 
-const fieldConfig = [
-    { input: pomodoroInput, key: "pomodoro", label: "Pomodoro", min: 1, max: 120, defaultValue: defaultSettings.pomodoro },
-    { input: shortBreakInput, key: "shortBreak", label: "Short break", min: 1, max: 30, defaultValue: defaultSettings.shortBreak },
-    { input: longBreakInput, key: "longBreak", label: "Long break", min: 1, max: 80, defaultValue: defaultSettings.longBreak }
-];
+const fieldConfig = (
+    settingsValidationApi
+        ? settingsValidationApi.buildFieldConfig(defaultSettings)
+        : [
+            { key: "pomodoro", label: "Pomodoro", min: 1, max: 120, defaultValue: defaultSettings.pomodoro },
+            { key: "shortBreak", label: "Short break", min: 1, max: 30, defaultValue: defaultSettings.shortBreak },
+            { key: "longBreak", label: "Long break", min: 1, max: 80, defaultValue: defaultSettings.longBreak }
+        ]
+).map(config => ({
+    ...config,
+    input: {
+        pomodoro: pomodoroInput,
+        shortBreak: shortBreakInput,
+        longBreak: longBreakInput
+    }[config.key]
+}));
 
 let savedSettings = loadSettingsFromStorage();
 
@@ -67,35 +79,71 @@ function showValidationError(message, invalidInputs) {
 }
 
 function normalizeMinuteInputValue(input, config) {
-    const rawValue = input.value.trim();
+    if (settingsValidationApi) {
+        const normalized = settingsValidationApi.normalizeMinuteValue(input.value, config);
+        input.value = normalized.displayValue;
+        return normalized;
+    }
 
+    const rawValue = input.value.trim();
     if (rawValue === "") {
-        return { value: null, isValid: false };
+        return { value: null, isValid: false, displayValue: "" };
     }
 
     const numericValue = Number(rawValue);
     if (!Number.isFinite(numericValue)) {
-        return { value: null, isValid: false };
+        return { value: null, isValid: false, displayValue: rawValue };
     }
 
     const flooredValue = Math.floor(numericValue);
-
     if (flooredValue < config.min) {
         input.value = String(config.defaultValue);
-        return { value: config.defaultValue, isValid: true };
+        return { value: config.defaultValue, isValid: true, displayValue: String(config.defaultValue) };
     }
 
     input.value = String(flooredValue);
-
     if (flooredValue > config.max) {
-        return { value: flooredValue, isValid: false };
+        return { value: flooredValue, isValid: false, displayValue: String(flooredValue) };
     }
 
-    return { value: flooredValue, isValid: true };
+    return { value: flooredValue, isValid: true, displayValue: String(flooredValue) };
 }
 
 function validateSettingsDraft() {
     clearValidationState();
+    const rawDraft = {
+        pomodoro: pomodoroInput.value,
+        shortBreak: shortBreakInput.value,
+        longBreak: longBreakInput.value,
+        soundEnabled: soundEnabledInput.checked
+    };
+
+    if (settingsValidationApi && timerStateStore) {
+        const validation = settingsValidationApi.validateSettingsDraftValues(
+            rawDraft,
+            fieldConfig,
+            timerStateStore.normalizeSettings
+        );
+
+        fieldConfig.forEach(config => {
+            const normalizedField = validation.fieldResults?.[config.key];
+            if (normalizedField && typeof normalizedField.displayValue === "string") {
+                config.input.value = normalizedField.displayValue;
+            }
+        });
+
+        if (!validation.isValid) {
+            const invalidField = fieldConfig.find(config => config.key === validation.invalidKey);
+            if (invalidField?.input) {
+                showValidationError(validation.message, [invalidField.input]);
+                invalidField.input.focus();
+            }
+            return null;
+        }
+
+        return validation.draft;
+    }
+
     const draft = {
         soundEnabled: soundEnabledInput.checked
     };
@@ -113,7 +161,7 @@ function validateSettingsDraft() {
         draft[key] = value;
     }
 
-    return timerStateStore.normalizeSettings(draft);
+    return timerStateStore ? timerStateStore.normalizeSettings(draft) : draft;
 }
 
 function openSettings() {

--- a/package.json
+++ b/package.json
@@ -6,9 +6,15 @@
     "start:test-server": "node tests/server.js",
     "test": "npm run test:unit && npm run test:e2e",
     "test:unit": "vitest run",
+    "test:unit:quiet": "TEST_EXPLANATIONS=0 vitest run",
     "test:unit:watch": "vitest",
-    "test:e2e": "playwright test",
-    "test:e2e:headed": "playwright test --headed"
+    "test:e2e": "playwright test -c playwright.config.js",
+    "test:e2e:quiet": "TEST_EXPLANATIONS=0 playwright test -c playwright.config.js",
+    "test:e2e:headed": "playwright test -c playwright.config.js --headed",
+    "test:smoke": "playwright test -c playwright.smoke.config.js",
+    "test:smoke:quiet": "TEST_EXPLANATIONS=0 playwright test -c playwright.smoke.config.js",
+    "test:regression": "playwright test -c playwright.regression.config.js",
+    "test:regression:quiet": "TEST_EXPLANATIONS=0 playwright test -c playwright.regression.config.js"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -4,7 +4,10 @@ module.exports = defineConfig({
     testDir: "./tests/e2e",
     timeout: 30_000,
     fullyParallel: true,
-    reporter: "list",
+    reporter: [
+        ["list"],
+        ["./tests/e2e/explanation-reporter.cjs"]
+    ],
     use: {
         baseURL: "http://127.0.0.1:4173",
         trace: "on-first-retry"

--- a/playwright.regression.config.js
+++ b/playwright.regression.config.js
@@ -1,5 +1,6 @@
 const { createPlaywrightConfig } = require("./tests/create-playwright-config.cjs");
 
 module.exports = createPlaywrightConfig({
-    port: 4173
+    port: 4175,
+    testMatch: /(timer|settings|productivity)\.spec\.js$/
 });

--- a/playwright.smoke.config.js
+++ b/playwright.smoke.config.js
@@ -1,5 +1,6 @@
 const { createPlaywrightConfig } = require("./tests/create-playwright-config.cjs");
 
 module.exports = createPlaywrightConfig({
-    port: 4173
+    port: 4174,
+    testMatch: /smoke\.spec\.js$/
 });

--- a/tests/create-playwright-config.cjs
+++ b/tests/create-playwright-config.cjs
@@ -1,0 +1,45 @@
+const { defineConfig } = require("@playwright/test");
+
+function buildReporter(showExplanations) {
+    return showExplanations
+        ? [
+            ["list"],
+            ["./tests/e2e/explanation-reporter.cjs"]
+        ]
+        : "list";
+}
+
+function createPlaywrightConfig(options = {}) {
+    const {
+        port = 4173,
+        testMatch,
+        grep
+    } = options;
+    const showExplanations = process.env.TEST_EXPLANATIONS !== "0";
+
+    return defineConfig({
+        testDir: "./tests/e2e",
+        timeout: 30_000,
+        fullyParallel: true,
+        reporter: buildReporter(showExplanations),
+        testMatch,
+        grep,
+        use: {
+            baseURL: `http://127.0.0.1:${port}`,
+            trace: "on-first-retry"
+        },
+        webServer: {
+            command: "node tests/server.js",
+            env: {
+                PORT: String(port)
+            },
+            port,
+            reuseExistingServer: true,
+            timeout: 30_000
+        }
+    });
+}
+
+module.exports = {
+    createPlaywrightConfig
+};

--- a/tests/e2e/explanation-reporter.cjs
+++ b/tests/e2e/explanation-reporter.cjs
@@ -1,0 +1,24 @@
+class E2EExplanationReporter {
+    onTestEnd(test, result) {
+        const fullName = test.titlePath().slice(1).join(" > ");
+        const expected = `The flow "${test.title}" should complete with every browser assertion passing.`;
+        const actual = result.status === "passed"
+            ? "PASS - the browser matched the expected UI and persistence behavior."
+            : `FAIL - ${result.error?.message || "see failure details above."}`;
+
+        console.info(
+            [
+                "",
+                `[E2E] ${fullName}`,
+                `Explanation: ${test.title}`,
+                `Expected: ${expected}`,
+                `Actual: ${actual}`,
+                `Status: ${result.status.toUpperCase()}`,
+                `Duration: ${result.duration}ms`,
+                `Retry: ${result.retry}`
+            ].join("\n")
+        );
+    }
+}
+
+module.exports = E2EExplanationReporter;

--- a/tests/e2e/productivity.spec.js
+++ b/tests/e2e/productivity.spec.js
@@ -1,23 +1,50 @@
 const { test, expect } = require("@playwright/test");
 
+function buildText(length, char = "x") {
+    return char.repeat(length);
+}
+
+async function addTodo(page, value) {
+    await page.fill("#todoInput", value);
+    await page.click('button:has-text("Add task")');
+}
+
+async function openNotes(page) {
+    await page.click('[data-tab-trigger="notes"]');
+    await expect(page.locator("#noteInput")).toBeVisible();
+}
+
+async function addNote(page, value) {
+    await openNotes(page);
+    await page.fill("#noteInput", value);
+    await page.click('button:has-text("Add note")');
+}
+
 test.describe("productivity page", () => {
     test("persists tasks and notes across reloads", async ({ page }) => {
         await page.goto("/productivity.html");
 
-        await page.fill("#todoInput", "Write integration notes");
-        await page.click('button:has-text("Add task")');
+        await addTodo(page, "Write integration notes");
         await expect(page.locator('[data-item-list="todo"]')).toContainText("Write integration notes");
 
-        await page.click('[data-tab-trigger="notes"]');
-        await page.fill("#noteInput", "Remember to validate localStorage recovery.");
-        await page.click('button:has-text("Add note")');
+        await addNote(page, "Remember to validate localStorage recovery.");
         await expect(page.locator('[data-item-list="notes"]')).toContainText("Remember to validate localStorage recovery.");
 
         await page.reload();
 
         await expect(page.locator('[data-item-list="todo"]')).toContainText("Write integration notes");
-        await page.click('[data-tab-trigger="notes"]');
+        await openNotes(page);
         await expect(page.locator('[data-item-list="notes"]')).toContainText("Remember to validate localStorage recovery.");
+    });
+
+    test("trims surrounding whitespace from new tasks and notes", async ({ page }) => {
+        await page.goto("/productivity.html");
+
+        await addTodo(page, "   Trimmed task   ");
+        await expect(page.locator('[data-item-list="todo"]')).toContainText("Trimmed task");
+
+        await addNote(page, "   Trimmed note   ");
+        await expect(page.locator('[data-item-list="notes"]')).toContainText("Trimmed note");
     });
 
     test("recovers from malformed productivity storage", async ({ page }) => {
@@ -29,17 +56,19 @@ test.describe("productivity page", () => {
 
         await expect(page.locator('[data-empty-state="todo"]')).toBeVisible();
         await expect(page.locator('[data-empty-state="notes"]')).toBeHidden();
-        await page.click('[data-tab-trigger="notes"]');
+        await openNotes(page);
         await expect(page.locator('[data-empty-state="notes"]')).toBeVisible();
     });
 
-    test("supports edit, complete, and delete flows for todos", async ({ page }) => {
+    test("supports edit, complete, uncomplete, and delete flows for todos", async ({ page }) => {
         await page.goto("/productivity.html");
 
-        await page.fill("#todoInput", "Original task");
-        await page.click('button:has-text("Add task")');
+        await addTodo(page, "Original task");
         await page.check('[data-action="toggle-complete"]');
         await expect(page.locator(".productivity-item__content")).toHaveClass(/completed/);
+
+        await page.uncheck('[data-action="toggle-complete"]');
+        await expect(page.locator(".productivity-item__content")).not.toHaveClass(/completed/);
 
         await page.click('[data-action="edit"]');
         await page.fill('[data-edit-field="todo"]', "Updated task");
@@ -50,26 +79,127 @@ test.describe("productivity page", () => {
         await expect(page.locator('[data-empty-state="todo"]')).toBeVisible();
     });
 
-    test("supports edit and keyboard save for notes", async ({ page }) => {
+    test("supports note editing, keyboard save, and delete flows", async ({ page }) => {
         await page.goto("/productivity.html");
-        await page.click('[data-tab-trigger="notes"]');
+        await addNote(page, "First note");
 
-        await page.fill("#noteInput", "First note");
-        await page.click('button:has-text("Add note")');
         await page.click('[data-action="edit"]');
         await page.fill('[data-edit-field="notes"]', "Updated note");
         await page.press('[data-edit-field="notes"]', "Meta+Enter");
         await expect(page.locator('[data-item-list="notes"]')).toContainText("Updated note");
+
+        await page.click('[data-action="edit"]');
+        await page.fill('[data-edit-field="notes"]', "Updated again");
+        await page.press('[data-edit-field="notes"]', "Control+Enter");
+        await expect(page.locator('[data-item-list="notes"]')).toContainText("Updated again");
+
+        await page.click('[data-action="delete"]');
+        await expect(page.locator('[data-empty-state="notes"]')).toBeVisible();
     });
 
-    test("shows validation for blank submissions", async ({ page }) => {
+    test("shows validation for blank and whitespace-only submissions", async ({ page }) => {
         await page.goto("/productivity.html");
         await page.click('button:has-text("Add task")');
         await expect(page.locator('[data-form-message="todo"]')).toContainText("Please enter a task before adding it.");
+        await expect(page.locator("#todoInput")).toHaveAttribute("aria-invalid", "true");
 
-        await page.click('[data-tab-trigger="notes"]');
+        await page.fill("#todoInput", "    ");
+        await page.click('button:has-text("Add task")');
+        await expect(page.locator('[data-form-message="todo"]')).toContainText("Please enter a task before adding it.");
+
+        await openNotes(page);
         await page.click('button:has-text("Add note")');
         await expect(page.locator('[data-form-message="notes"]')).toContainText("Please enter a note before adding it.");
+        await expect(page.locator("#noteInput")).toHaveAttribute("aria-invalid", "true");
+
+        await page.fill("#noteInput", "   ");
+        await page.click('button:has-text("Add note")');
+        await expect(page.locator('[data-form-message="notes"]')).toContainText("Please enter a note before adding it.");
+    });
+
+    test("clears form validation after the user starts typing again", async ({ page }) => {
+        await page.goto("/productivity.html");
+        await page.click('button:has-text("Add task")');
+        await expect(page.locator("#todoInput")).toHaveAttribute("aria-invalid", "true");
+
+        await page.fill("#todoInput", "Recovered task");
+        await expect(page.locator('[data-form-message="todo"]')).toBeHidden();
+        await expect(page.locator("#todoInput")).not.toHaveAttribute("aria-invalid", "true");
+    });
+
+    test("keeps the original item when todo edit is cancelled", async ({ page }) => {
+        await page.goto("/productivity.html");
+        await addTodo(page, "Keep me");
+
+        await page.click('[data-action="edit"]');
+        await page.fill('[data-edit-field="todo"]', "Discarded change");
+        await page.click('button:has-text("Cancel")');
+
+        await expect(page.locator('[data-item-list="todo"]')).toContainText("Keep me");
+        await expect(page.locator('[data-item-list="todo"]')).not.toContainText("Discarded change");
+    });
+
+    test("keeps the original item when note edit is cancelled", async ({ page }) => {
+        await page.goto("/productivity.html");
+        await addNote(page, "Keep this note");
+
+        await page.click('[data-action="edit"]');
+        await page.fill('[data-edit-field="notes"]', "Discarded note");
+        await page.click('button:has-text("Cancel")');
+
+        await expect(page.locator('[data-item-list="notes"]')).toContainText("Keep this note");
+        await expect(page.locator('[data-item-list="notes"]')).not.toContainText("Discarded note");
+    });
+
+    test("rejects blank todo edits and keeps the editor open", async ({ page }) => {
+        await page.goto("/productivity.html");
+        await addTodo(page, "Editable task");
+
+        await page.click('[data-action="edit"]');
+        await page.fill('[data-edit-field="todo"]', "   ");
+        await page.press('[data-edit-field="todo"]', "Enter");
+
+        await expect(page.locator('[data-edit-field="todo"]')).toBeVisible();
+        await expect(page.locator('[data-edit-field="todo"]')).toHaveAttribute("aria-invalid", "true");
+    });
+
+    test("rejects blank note edits and keeps the editor open", async ({ page }) => {
+        await page.goto("/productivity.html");
+        await addNote(page, "Editable note");
+
+        await page.click('[data-action="edit"]');
+        await page.fill('[data-edit-field="notes"]', "   ");
+        await page.press('[data-edit-field="notes"]', "Control+Enter");
+
+        await expect(page.locator('[data-edit-field="notes"]')).toBeVisible();
+        await expect(page.locator('[data-edit-field="notes"]')).toHaveAttribute("aria-invalid", "true");
+    });
+
+    test("enforces the task maxlength during real typing", async ({ page }) => {
+        const taskValue = buildText(160, "t");
+        const overflow = buildText(10, "z");
+
+        await page.goto("/productivity.html");
+        await page.locator("#todoInput").focus();
+        await page.keyboard.type(taskValue + overflow);
+
+        await expect(page.locator("#todoInput")).toHaveValue(taskValue);
+        await page.click('button:has-text("Add task")');
+        await expect(page.locator(".productivity-item__content")).toHaveText(taskValue);
+    });
+
+    test("enforces the note maxlength during real typing", async ({ page }) => {
+        const noteValue = buildText(1200, "n");
+        const overflow = buildText(20, "z");
+
+        await page.goto("/productivity.html");
+        await openNotes(page);
+        await page.locator("#noteInput").focus();
+        await page.keyboard.type(noteValue + overflow);
+
+        await expect(page.locator("#noteInput")).toHaveValue(noteValue);
+        await page.click('button:has-text("Add note")');
+        await expect(page.locator(".productivity-note__content")).toHaveText(noteValue);
     });
 
     test("syncs storage changes across two productivity pages", async ({ browser }) => {
@@ -80,11 +210,27 @@ test.describe("productivity page", () => {
         await firstPage.goto("/productivity.html");
         await secondPage.goto("/productivity.html");
 
-        await firstPage.fill("#todoInput", "Shared task");
-        await firstPage.click('button:has-text("Add task")');
-
+        await addTodo(firstPage, "Shared task");
         await expect(secondPage.locator('[data-item-list="todo"]')).toContainText("Shared task");
 
+        await addNote(firstPage, "Shared note");
+        await openNotes(secondPage);
+        await expect(secondPage.locator('[data-item-list="notes"]')).toContainText("Shared note");
+
         await context.close();
+    });
+
+    test("keeps tabs and aria state in sync when switching between todo and notes", async ({ page }) => {
+        await page.goto("/productivity.html");
+
+        await expect(page.locator('#productivity-tab-todo')).toHaveAttribute("aria-selected", "true");
+        await expect(page.locator('#productivity-panel-todo')).toHaveAttribute("aria-hidden", "false");
+        await expect(page.locator('#productivity-panel-notes')).toHaveAttribute("aria-hidden", "true");
+
+        await openNotes(page);
+
+        await expect(page.locator('#productivity-tab-notes')).toHaveAttribute("aria-selected", "true");
+        await expect(page.locator('#productivity-panel-notes')).toHaveAttribute("aria-hidden", "false");
+        await expect(page.locator('#productivity-panel-todo')).toHaveAttribute("aria-hidden", "true");
     });
 });

--- a/tests/e2e/productivity.spec.js
+++ b/tests/e2e/productivity.spec.js
@@ -161,6 +161,7 @@ test.describe("productivity page", () => {
 
         await expect(page.locator('[data-edit-field="todo"]')).toBeVisible();
         await expect(page.locator('[data-edit-field="todo"]')).toHaveAttribute("aria-invalid", "true");
+        await expect(page.locator('[data-edit-message="todo"]')).toContainText("Please enter a task before saving it.");
     });
 
     test("rejects blank note edits and keeps the editor open", async ({ page }) => {
@@ -173,6 +174,28 @@ test.describe("productivity page", () => {
 
         await expect(page.locator('[data-edit-field="notes"]')).toBeVisible();
         await expect(page.locator('[data-edit-field="notes"]')).toHaveAttribute("aria-invalid", "true");
+        await expect(page.locator('[data-edit-message="notes"]')).toContainText("Please enter a note before saving it.");
+    });
+
+    test("drops invalid productivity entries seeded directly in localStorage", async ({ page }) => {
+        await page.addInitScript(() => {
+            localStorage.setItem("pomodoroProductivity.v1", JSON.stringify({
+                todo: [
+                    { id: "t1", text: "   ", completed: false, createdAt: "bad", updatedAt: "bad" },
+                    { id: "t2", text: "A".repeat(200), completed: false, createdAt: "2026-04-01T10:00:00.000Z", updatedAt: "2026-04-01T10:00:00.000Z" }
+                ],
+                notes: [
+                    { id: "n1", content: "   ", createdAt: "bad", updatedAt: "bad" },
+                    { id: "n2", content: "B".repeat(1400), createdAt: "2026-04-01T10:00:00.000Z", updatedAt: "2026-04-01T10:00:00.000Z" }
+                ]
+            }));
+        });
+
+        await page.goto("/productivity.html");
+        await expect(page.locator(".productivity-item__content")).toHaveText("A".repeat(160));
+
+        await openNotes(page);
+        await expect(page.locator(".productivity-note__content")).toHaveText("B".repeat(1200));
     });
 
     test("enforces the task maxlength during real typing", async ({ page }) => {

--- a/tests/e2e/settings.spec.js
+++ b/tests/e2e/settings.spec.js
@@ -1,5 +1,44 @@
 const { test, expect } = require("@playwright/test");
 
+const fieldCases = [
+    {
+        key: "pomodoro",
+        selector: "#pomodoroTime",
+        min: 1,
+        max: 120,
+        defaultValue: 25,
+        validValue: 30,
+        decimalValue: "5.9",
+        flooredValue: "5",
+        aboveMax: "121",
+        error: "Pomodoro must be between 1 and 120."
+    },
+    {
+        key: "shortBreak",
+        selector: "#shortBreakTime",
+        min: 1,
+        max: 30,
+        defaultValue: 5,
+        validValue: 6,
+        decimalValue: "7.9",
+        flooredValue: "7",
+        aboveMax: "31",
+        error: "Short break must be between 1 and 30."
+    },
+    {
+        key: "longBreak",
+        selector: "#longBreakTime",
+        min: 1,
+        max: 80,
+        defaultValue: 15,
+        validValue: 20,
+        decimalValue: "9.9",
+        flooredValue: "9",
+        aboveMax: "81",
+        error: "Long break must be between 1 and 80."
+    }
+];
+
 async function openSettings(page) {
     await page.goto("/index.html");
     await page.click("#settingsToggle");
@@ -31,6 +70,11 @@ async function saveSettings(page, { pomodoro, shortBreak, longBreak, soundEnable
     }
 
     await page.click("#saveSettings");
+}
+
+async function changeAndBlur(page, selector, rawValue) {
+    await page.fill(selector, rawValue);
+    await page.locator(selector).dispatchEvent("change");
 }
 
 test.describe("timer settings automation", () => {
@@ -96,6 +140,26 @@ test.describe("timer settings automation", () => {
         });
     });
 
+    test("persists sound toggle changes off and back on", async ({ page }) => {
+        await openSettings(page);
+        await saveSettings(page, {
+            pomodoro: 25,
+            shortBreak: 5,
+            longBreak: 15,
+            soundEnabled: false
+        });
+
+        await page.reload();
+        await page.click("#settingsToggle");
+        await expect(page.locator("#soundEnabled")).not.toBeChecked();
+
+        await page.check("#soundEnabled");
+        await page.click("#saveSettings");
+        await page.reload();
+        await page.click("#settingsToggle");
+        await expect(page.locator("#soundEnabled")).toBeChecked();
+    });
+
     test("cancel discards unsaved changes", async ({ page }) => {
         await openSettings(page);
         await saveSettings(page, {
@@ -121,71 +185,92 @@ test.describe("timer settings automation", () => {
         });
     });
 
-    test("rejects blank pomodoro values", async ({ page }) => {
+    for (const fieldCase of fieldCases) {
+        test(`floors decimal ${fieldCase.key} values on change and save`, async ({ page }) => {
+            await openSettings(page);
+            await changeAndBlur(page, fieldCase.selector, fieldCase.decimalValue);
+            await expect(page.locator(fieldCase.selector)).toHaveValue(fieldCase.flooredValue);
+
+            await page.click("#saveSettings");
+            await expect(page.locator("#settingsError")).toBeHidden();
+            await expect(page.locator("#settingsSection")).toHaveClass(/hidden/);
+
+            await page.click("#settingsToggle");
+            await expect(page.locator(fieldCase.selector)).toHaveValue(fieldCase.flooredValue);
+        });
+
+        test(`defaults ${fieldCase.key} to its configured default when zero is entered`, async ({ page }) => {
+            await openSettings(page);
+            await changeAndBlur(page, fieldCase.selector, "0");
+            await expect(page.locator(fieldCase.selector)).toHaveValue(String(fieldCase.defaultValue));
+
+            await page.click("#saveSettings");
+            await expect(page.locator("#settingsSection")).toHaveClass(/hidden/);
+            await page.click("#settingsToggle");
+            await expect(page.locator(fieldCase.selector)).toHaveValue(String(fieldCase.defaultValue));
+        });
+
+        test(`defaults negative ${fieldCase.key} values back to its default`, async ({ page }) => {
+            await openSettings(page);
+            await changeAndBlur(page, fieldCase.selector, "-4");
+            await expect(page.locator(fieldCase.selector)).toHaveValue(String(fieldCase.defaultValue));
+        });
+
+        test(`rejects blank ${fieldCase.key} values`, async ({ page }) => {
+            await openSettings(page);
+            await page.locator(fieldCase.selector).clear();
+            await page.click("#saveSettings");
+
+            await expect(page.locator("#settingsError")).toContainText(fieldCase.error);
+            await expect(page.locator(fieldCase.selector)).toHaveAttribute("aria-invalid", "true");
+        });
+
+        test(`rejects ${fieldCase.key} values above the allowed range`, async ({ page }) => {
+            await openSettings(page);
+            await page.fill(fieldCase.selector, fieldCase.aboveMax);
+            await page.click("#saveSettings");
+
+            await expect(page.locator("#settingsError")).toContainText(fieldCase.error);
+            await expect(page.locator(fieldCase.selector)).toHaveAttribute("aria-invalid", "true");
+        });
+    }
+
+    test("clears validation state after the user edits an invalid field", async ({ page }) => {
         await openSettings(page);
-        await page.locator("#pomodoroTime").clear();
+        await page.fill("#pomodoroTime", "121");
         await page.click("#saveSettings");
 
         await expect(page.locator("#settingsError")).toContainText("Pomodoro must be between 1 and 120.");
         await expect(page.locator("#pomodoroTime")).toHaveAttribute("aria-invalid", "true");
+
+        await page.fill("#pomodoroTime", "60");
+        await expect(page.locator("#settingsError")).toBeHidden();
+        await expect(page.locator("#pomodoroTime")).not.toHaveAttribute("aria-invalid", "true");
     });
 
-    test("rejects pomodoro values below and above range", async ({ page }) => {
-        await openSettings(page);
+    test("syncs visible settings inputs when storage changes in another page", async ({ browser }) => {
+        const context = await browser.newContext();
+        const firstPage = await context.newPage();
+        const secondPage = await context.newPage();
 
-        await page.fill("#pomodoroTime", "0");
-        await page.click("#saveSettings");
-        await expect(page.locator("#settingsError")).toBeHidden();
-        await expect(page.locator("#settingsSection")).toHaveClass(/hidden/);
-        await page.click("#settingsToggle");
-        await expect(page.locator("#pomodoroTime")).toHaveValue("25");
+        await firstPage.goto("/index.html");
+        await firstPage.click("#settingsToggle");
+        await secondPage.goto("/index.html");
+        await secondPage.click("#settingsToggle");
 
-        await page.fill("#pomodoroTime", "121");
-        await page.click("#saveSettings");
-        await expect(page.locator("#settingsError")).toContainText("Pomodoro must be between 1 and 120.");
-    });
+        await saveSettings(secondPage, {
+            pomodoro: 44,
+            shortBreak: 9,
+            longBreak: 24,
+            soundEnabled: false
+        });
 
-    test("defaults short break values below range and rejects values above range", async ({ page }) => {
-        await openSettings(page);
+        await expect(firstPage.locator("#pomodoroTime")).toHaveValue("44");
+        await expect(firstPage.locator("#shortBreakTime")).toHaveValue("9");
+        await expect(firstPage.locator("#longBreakTime")).toHaveValue("24");
+        await expect(firstPage.locator("#soundEnabled")).not.toBeChecked();
 
-        await page.fill("#shortBreakTime", "0");
-        await page.click("#saveSettings");
-        await expect(page.locator("#settingsError")).toBeHidden();
-        await expect(page.locator("#settingsSection")).toHaveClass(/hidden/);
-        await page.click("#settingsToggle");
-        await expect(page.locator("#shortBreakTime")).toHaveValue("5");
-
-        await page.fill("#shortBreakTime", "31");
-        await page.click("#saveSettings");
-        await expect(page.locator("#settingsError")).toContainText("Short break must be between 1 and 30.");
-    });
-
-    test("defaults long break values below range and rejects values above range", async ({ page }) => {
-        await openSettings(page);
-
-        await page.fill("#longBreakTime", "0");
-        await page.click("#saveSettings");
-        await expect(page.locator("#settingsError")).toBeHidden();
-        await expect(page.locator("#settingsSection")).toHaveClass(/hidden/);
-        await page.click("#settingsToggle");
-        await expect(page.locator("#longBreakTime")).toHaveValue("15");
-
-        await page.fill("#longBreakTime", "81");
-        await page.click("#saveSettings");
-        await expect(page.locator("#settingsError")).toContainText("Long break must be between 1 and 80.");
-    });
-
-    test("rejects non-integer values", async ({ page }) => {
-        await openSettings(page);
-
-        await page.fill("#pomodoroTime", "2.5");
-        await page.click("#saveSettings");
-        await expect(page.locator("#settingsError")).toBeHidden();
-        await expect(page.locator("#settingsSection")).toHaveClass(/hidden/);
-        await expect(page.locator("#timeDisplay")).toHaveText("02:00");
-
-        await page.click("#settingsToggle");
-        await expect(page.locator("#pomodoroTime")).toHaveValue("2");
+        await context.close();
     });
 
     test("prevents opening settings while the timer is running", async ({ page }) => {

--- a/tests/e2e/settings.spec.js
+++ b/tests/e2e/settings.spec.js
@@ -210,10 +210,13 @@ test.describe("timer settings automation", () => {
             await expect(page.locator(fieldCase.selector)).toHaveValue(String(fieldCase.defaultValue));
         });
 
-        test(`defaults negative ${fieldCase.key} values back to its default`, async ({ page }) => {
+        test(`rejects negative ${fieldCase.key} values`, async ({ page }) => {
             await openSettings(page);
             await changeAndBlur(page, fieldCase.selector, "-4");
-            await expect(page.locator(fieldCase.selector)).toHaveValue(String(fieldCase.defaultValue));
+            await expect(page.locator(fieldCase.selector)).toHaveValue("-4");
+            await page.click("#saveSettings");
+            await expect(page.locator("#settingsError")).toContainText(fieldCase.error);
+            await expect(page.locator(fieldCase.selector)).toHaveAttribute("aria-invalid", "true");
         });
 
         test(`rejects blank ${fieldCase.key} values`, async ({ page }) => {
@@ -234,6 +237,28 @@ test.describe("timer settings automation", () => {
             await expect(page.locator(fieldCase.selector)).toHaveAttribute("aria-invalid", "true");
         });
     }
+
+    test("rejects scientific notation in settings fields", async ({ page }) => {
+        await openSettings(page);
+        await page.fill("#pomodoroTime", "1e2");
+        await page.click("#saveSettings");
+
+        await expect(page.locator("#settingsError")).toContainText("Pomodoro must be between 1 and 120.");
+        await expect(page.locator("#pomodoroTime")).toHaveAttribute("aria-invalid", "true");
+    });
+
+    test("rejects hexadecimal-like values in settings fields", async ({ page }) => {
+        await openSettings(page);
+        await page.evaluate(() => {
+            const input = document.querySelector("#pomodoroTime");
+            input.value = "0x10";
+            input.dispatchEvent(new Event("input", { bubbles: true }));
+        });
+        await page.click("#saveSettings");
+
+        await expect(page.locator("#settingsError")).toContainText("Pomodoro must be between 1 and 120.");
+        await expect(page.locator("#pomodoroTime")).toHaveAttribute("aria-invalid", "true");
+    });
 
     test("clears validation state after the user edits an invalid field", async ({ page }) => {
         await openSettings(page);

--- a/tests/e2e/smoke.spec.js
+++ b/tests/e2e/smoke.spec.js
@@ -1,0 +1,79 @@
+const { test, expect } = require("@playwright/test");
+
+const pageCases = [
+    {
+        path: "/index.html",
+        title: "Pomodoro Web",
+        heading: "Deep work with a visible finish line.",
+        activeNav: "Timer",
+        hasMiniTimer: false
+    },
+    {
+        path: "/productivity.html",
+        title: "Productivity - Pomodoro Web",
+        heading: "Productivity",
+        activeNav: "Productivity",
+        hasMiniTimer: true
+    },
+    {
+        path: "/about.html",
+        title: "About - Pomodoro Web",
+        heading: "About This App",
+        activeNav: "About",
+        hasMiniTimer: true
+    },
+    {
+        path: "/helpus.html",
+        title: "Help Us - Pomodoro Web",
+        heading: "Help Us",
+        activeNav: "Help Us",
+        hasMiniTimer: true
+    }
+];
+
+test.describe("smoke coverage", () => {
+    for (const pageCase of pageCases) {
+        test(`renders ${pageCase.path} with the main shell`, async ({ page }) => {
+            await page.goto(pageCase.path);
+
+            await expect(page).toHaveTitle(pageCase.title);
+            await expect(page.locator(".header")).toBeVisible();
+            await expect(page.getByRole("heading", { name: pageCase.heading })).toBeVisible();
+            await expect(page.locator(".footer")).toBeVisible();
+            await expect(page.locator(`.nav-btn--active:has-text("${pageCase.activeNav}")`)).toBeVisible();
+
+            if (pageCase.hasMiniTimer) {
+                await expect(page.locator("#miniTimer")).toBeVisible();
+                await expect(page.locator("#miniTimerTime")).toHaveText(/\d{2}:\d{2}|\d{3}:\d{2}/);
+            } else {
+                await expect(page.locator("#miniTimer")).toHaveCount(0);
+            }
+        });
+    }
+
+    test("navigates through all main pages from the header", async ({ page }) => {
+        await page.goto("/index.html");
+        await page.click('a[href="productivity.html"]');
+        await expect(page).toHaveURL(/productivity\.html$/);
+        await page.click('a[href="about.html"]');
+        await expect(page).toHaveURL(/about\.html$/);
+        await page.click('a[href="helpus.html"]');
+        await expect(page).toHaveURL(/helpus\.html$/);
+        await page.click('a[href="index.html"]');
+        await expect(page).toHaveURL(/index\.html$/);
+    });
+
+    test("shows the main interactive controls on timer and productivity pages", async ({ page }) => {
+        await page.goto("/index.html");
+        await expect(page.locator("#timeDisplay")).toHaveText("25:00");
+        await expect(page.locator("#startBtn")).toBeVisible();
+        await expect(page.locator("#resetBtn")).toBeVisible();
+        await expect(page.locator("#settingsToggle")).toBeVisible();
+
+        await page.goto("/productivity.html");
+        await expect(page.locator("#todoInput")).toBeVisible();
+        await expect(page.locator("#noteInput")).toBeHidden();
+        await page.click('[data-tab-trigger="notes"]');
+        await expect(page.locator("#noteInput")).toBeVisible();
+    });
+});

--- a/tests/unit/explanation-reporter.cjs
+++ b/tests/unit/explanation-reporter.cjs
@@ -1,0 +1,26 @@
+class UnitExplanationReporter {
+    onTestCaseResult(testCase) {
+        const result = testCase.result();
+        const diagnostic = testCase.diagnostic?.();
+        const status = (result?.state || "unknown").toUpperCase();
+        const duration = diagnostic?.duration != null ? `${diagnostic.duration}ms` : "n/a";
+        const expected = `The scenario "${testCase.name}" should satisfy all assertions and finish successfully.`;
+        const actual = result?.state === "passed"
+            ? `PASS - observed behavior matched every assertion.`
+            : `FAIL - ${result?.errors?.[0]?.message || "see failure details above."}`;
+
+        console.info(
+            [
+                "",
+                `[UNIT] ${testCase.fullName}`,
+                `Explanation: ${testCase.name}`,
+                `Expected: ${expected}`,
+                `Actual: ${actual}`,
+                `Status: ${status}`,
+                `Duration: ${duration}`
+            ].join("\n")
+        );
+    }
+}
+
+module.exports = UnitExplanationReporter;

--- a/tests/unit/productivity-store.spec.js
+++ b/tests/unit/productivity-store.spec.js
@@ -3,7 +3,9 @@ import productivityStoreApi from "../../js/productivity-store.js";
 
 const {
     STORAGE_KEY,
+    ITEM_LIMITS,
     isValidTimestamp,
+    sanitizeTextValue,
     normalizeProductivityState,
     createProductivityStore
 } = productivityStoreApi;
@@ -23,6 +25,8 @@ describe("productivity-store", () => {
     it("uses the expected storage key", () => {
         expect(STORAGE_KEY).toBe("pomodoroProductivity.v1");
         expect(store.key).toBe(STORAGE_KEY);
+        expect(ITEM_LIMITS.todo).toBe(160);
+        expect(ITEM_LIMITS.notes).toBe(1200);
     });
 
     it("returns a fresh empty state object each time", () => {
@@ -42,14 +46,22 @@ describe("productivity-store", () => {
         expect(isValidTimestamp(null)).toBe(false);
     });
 
+    it("trims values, enforces maximum lengths, and rejects blank strings", () => {
+        expect(sanitizeTextValue("  hello  ", ITEM_LIMITS.todo)).toBe("hello");
+        expect(sanitizeTextValue("   ", ITEM_LIMITS.todo)).toBe(null);
+        expect(sanitizeTextValue("x".repeat(200), ITEM_LIMITS.todo)).toHaveLength(160);
+    });
+
     it("normalizes corrupted raw state into a safe empty/default structure", () => {
         expect(normalizeProductivityState({
             todo: [
                 { id: "1", text: "keep", completed: "yes", createdAt: "bad", updatedAt: "bad" },
+                { id: "2", text: "   ", completed: false },
                 { text: "drop-no-id" }
             ],
             notes: [
                 { id: "n1", content: "keep note", createdAt: "bad", updatedAt: "2026-04-07T10:00:00.000Z" },
+                { id: "n3", content: "   " },
                 { id: "n2", text: "drop-no-content" }
             ]
         }, () => fixedNow)).toEqual({
@@ -114,7 +126,7 @@ describe("productivity-store", () => {
 
     it("creates todo items at the top of the list", () => {
         const result = store.create("todo", {
-            text: "Write tests",
+            text: "  Write tests  ",
             completed: false
         });
 
@@ -144,7 +156,7 @@ describe("productivity-store", () => {
 
     it("creates notes with timestamps", () => {
         const result = store.create("notes", {
-            content: "Remember edge cases"
+            content: "  Remember edge cases  "
         });
 
         expect(result[0]).toEqual({
@@ -153,6 +165,17 @@ describe("productivity-store", () => {
             createdAt: fixedNow.toISOString(),
             updatedAt: fixedNow.toISOString()
         });
+    });
+
+    it("refuses to create blank items", () => {
+        expect(store.create("todo", {
+            text: "   ",
+            completed: false
+        })).toEqual([]);
+
+        expect(store.create("notes", {
+            content: "   "
+        })).toEqual([]);
     });
 
     it("updates matching items and preserves others", () => {
@@ -217,6 +240,32 @@ describe("productivity-store", () => {
                 createdAt: "2026-04-07T11:00:00.000Z",
                 updatedAt: fixedNow.toISOString()
             }
+        ]);
+    });
+
+    it("rejects blank updates and keeps the previous item content", () => {
+        store.save({
+            todo: [{
+                id: "a",
+                text: "Only",
+                completed: false,
+                createdAt: fixedNow.toISOString(),
+                updatedAt: fixedNow.toISOString()
+            }],
+            notes: [{
+                id: "n1",
+                content: "Saved",
+                createdAt: fixedNow.toISOString(),
+                updatedAt: fixedNow.toISOString()
+            }]
+        });
+
+        expect(store.update("todo", "a", { text: "   " })).toEqual([
+            { id: "a", text: "Only", completed: false, createdAt: fixedNow.toISOString(), updatedAt: fixedNow.toISOString() }
+        ]);
+
+        expect(store.update("notes", "n1", { content: "   " })).toEqual([
+            { id: "n1", content: "Saved", createdAt: fixedNow.toISOString(), updatedAt: fixedNow.toISOString() }
         ]);
     });
 

--- a/tests/unit/productivity-store.spec.js
+++ b/tests/unit/productivity-store.spec.js
@@ -25,6 +25,17 @@ describe("productivity-store", () => {
         expect(store.key).toBe(STORAGE_KEY);
     });
 
+    it("returns a fresh empty state object each time", () => {
+        const first = store.emptyState();
+        const second = store.emptyState();
+
+        expect(first).toEqual({ todo: [], notes: [] });
+        expect(second).toEqual({ todo: [], notes: [] });
+        expect(first).not.toBe(second);
+        expect(first.todo).not.toBe(second.todo);
+        expect(first.notes).not.toBe(second.notes);
+    });
+
     it("validates timestamps safely", () => {
         expect(isValidTimestamp("2026-04-07T12:00:00.000Z")).toBe(true);
         expect(isValidTimestamp("not-a-date")).toBe(false);
@@ -65,6 +76,16 @@ describe("productivity-store", () => {
         expect(store.load()).toEqual({ todo: [], notes: [] });
     });
 
+    it("treats non-array top-level collections as empty lists", () => {
+        expect(normalizeProductivityState({
+            todo: "bad",
+            notes: { also: "bad" }
+        }, () => fixedNow)).toEqual({
+            todo: [],
+            notes: []
+        });
+    });
+
     it("saves normalized state back to storage", () => {
         const saved = store.save({
             todo: [{ id: "1", text: "Task", completed: false, createdAt: "bad", updatedAt: "bad" }],
@@ -74,6 +95,21 @@ describe("productivity-store", () => {
         expect(saved.todo).toHaveLength(1);
         expect(saved.notes).toEqual([]);
         expect(JSON.parse(localStorage.getItem(STORAGE_KEY))).toEqual(saved);
+    });
+
+    it("supports a custom storage key", () => {
+        const customStore = createProductivityStore(localStorage, {
+            key: "custom-productivity-key",
+            nowProvider: () => fixedNow,
+            idFactory: () => "custom-id"
+        });
+
+        customStore.save({
+            todo: [{ id: "1", text: "Task", completed: false, createdAt: fixedNow.toISOString(), updatedAt: fixedNow.toISOString() }],
+            notes: []
+        });
+
+        expect(localStorage.getItem("custom-productivity-key")).toContain("Task");
     });
 
     it("creates todo items at the top of the list", () => {
@@ -90,6 +126,20 @@ describe("productivity-store", () => {
             updatedAt: fixedNow.toISOString()
         });
         expect(store.load().todo).toHaveLength(1);
+    });
+
+    it("prepends newly created todo items ahead of existing ones", () => {
+        store.save({
+            todo: [{ id: "older", text: "Older", completed: false, createdAt: fixedNow.toISOString(), updatedAt: fixedNow.toISOString() }],
+            notes: []
+        });
+
+        const result = store.create("todo", {
+            text: "Newest",
+            completed: false
+        });
+
+        expect(result.map(item => item.id)).toEqual(["fixed-id", "older"]);
     });
 
     it("creates notes with timestamps", () => {
@@ -149,6 +199,27 @@ describe("productivity-store", () => {
         ]);
     });
 
+    it("updates note content and refreshes only the note timestamp", () => {
+        store.save({
+            todo: [],
+            notes: [{
+                id: "n1",
+                content: "Draft",
+                createdAt: "2026-04-07T11:00:00.000Z",
+                updatedAt: "2026-04-07T11:00:00.000Z"
+            }]
+        });
+
+        expect(store.update("notes", "n1", { content: "Final" })).toEqual([
+            {
+                id: "n1",
+                content: "Final",
+                createdAt: "2026-04-07T11:00:00.000Z",
+                updatedAt: fixedNow.toISOString()
+            }
+        ]);
+    });
+
     it("deletes matching items only", () => {
         store.save({
             todo: [
@@ -161,6 +232,21 @@ describe("productivity-store", () => {
         expect(store.delete("todo", "a")).toEqual([
             { id: "b", text: "Second", completed: false, createdAt: fixedNow.toISOString(), updatedAt: fixedNow.toISOString() }
         ]);
+    });
+
+    it("deletes notes independently from todo items", () => {
+        store.save({
+            todo: [{ id: "t1", text: "Task", completed: false, createdAt: fixedNow.toISOString(), updatedAt: fixedNow.toISOString() }],
+            notes: [
+                { id: "n1", content: "One", createdAt: fixedNow.toISOString(), updatedAt: fixedNow.toISOString() },
+                { id: "n2", content: "Two", createdAt: fixedNow.toISOString(), updatedAt: fixedNow.toISOString() }
+            ]
+        });
+
+        expect(store.delete("notes", "n1")).toEqual([
+            { id: "n2", content: "Two", createdAt: fixedNow.toISOString(), updatedAt: fixedNow.toISOString() }
+        ]);
+        expect(store.load().todo).toHaveLength(1);
     });
 
     it("keeps state unchanged when updating or deleting unknown ids", () => {

--- a/tests/unit/settings-validation.spec.js
+++ b/tests/unit/settings-validation.spec.js
@@ -1,0 +1,197 @@
+import { describe, it, expect } from "vitest";
+import settingsValidation from "../../js/settings-validation.js";
+
+const {
+    DEFAULT_SETTINGS,
+    FIELD_LIMITS,
+    buildFieldConfig,
+    normalizeMinuteValue,
+    validateSettingsDraftValues
+} = settingsValidation;
+
+describe("settings-validation", () => {
+    it("builds field config with labels, limits, and default values", () => {
+        expect(buildFieldConfig({
+            pomodoro: 40,
+            shortBreak: 7,
+            longBreak: 22
+        })).toEqual([
+            {
+                key: "pomodoro",
+                label: "Pomodoro",
+                min: 1,
+                max: 120,
+                defaultValue: 40
+            },
+            {
+                key: "shortBreak",
+                label: "Short break",
+                min: 1,
+                max: 30,
+                defaultValue: 7
+            },
+            {
+                key: "longBreak",
+                label: "Long break",
+                min: 1,
+                max: 80,
+                defaultValue: 22
+            }
+        ]);
+    });
+
+    it("exports the expected default settings and field limits", () => {
+        expect(DEFAULT_SETTINGS).toEqual({
+            pomodoro: 25,
+            shortBreak: 5,
+            longBreak: 15,
+            soundEnabled: true
+        });
+        expect(FIELD_LIMITS.pomodoro.max).toBe(120);
+        expect(FIELD_LIMITS.shortBreak.max).toBe(30);
+        expect(FIELD_LIMITS.longBreak.max).toBe(80);
+    });
+
+    it("accepts valid integer values unchanged", () => {
+        expect(normalizeMinuteValue("45", buildFieldConfig()[0])).toEqual({
+            value: 45,
+            isValid: true,
+            displayValue: "45",
+            reason: "valid"
+        });
+    });
+
+    it("floors decimal values and returns the floored display value", () => {
+        expect(normalizeMinuteValue("5.9", buildFieldConfig()[0])).toEqual({
+            value: 5,
+            isValid: true,
+            displayValue: "5",
+            reason: "floored"
+        });
+    });
+
+    it("defaults zero and negative values back to each field default", () => {
+        expect(normalizeMinuteValue("0", buildFieldConfig()[0])).toEqual({
+            value: 25,
+            isValid: true,
+            displayValue: "25",
+            reason: "below-min-defaulted"
+        });
+
+        expect(normalizeMinuteValue("-8", buildFieldConfig()[1])).toEqual({
+            value: 5,
+            isValid: true,
+            displayValue: "5",
+            reason: "below-min-defaulted"
+        });
+    });
+
+    it("rejects blank values", () => {
+        expect(normalizeMinuteValue("", buildFieldConfig()[2])).toEqual({
+            value: null,
+            isValid: false,
+            displayValue: "",
+            reason: "blank"
+        });
+    });
+
+    it("rejects non-numeric values", () => {
+        expect(normalizeMinuteValue("abc", buildFieldConfig()[0])).toEqual({
+            value: null,
+            isValid: false,
+            displayValue: "abc",
+            reason: "non-numeric"
+        });
+    });
+
+    it("rejects values above the allowed maximum while preserving the visible number", () => {
+        expect(normalizeMinuteValue("121", buildFieldConfig()[0])).toEqual({
+            value: 121,
+            isValid: false,
+            displayValue: "121",
+            reason: "above-max"
+        });
+    });
+
+    it("trims surrounding whitespace before validation", () => {
+        expect(normalizeMinuteValue("  14.8  ", buildFieldConfig()[1])).toEqual({
+            value: 14,
+            isValid: true,
+            displayValue: "14",
+            reason: "floored"
+        });
+    });
+
+    it("validates a full draft and normalizes each minute field", () => {
+        const result = validateSettingsDraftValues({
+            pomodoro: "50.7",
+            shortBreak: "0",
+            longBreak: "79.9",
+            soundEnabled: false
+        }, buildFieldConfig(), draft => ({
+            ...draft,
+            normalized: true
+        }));
+
+        expect(result.isValid).toBe(true);
+        expect(result.invalidKey).toBeNull();
+        expect(result.draft).toEqual({
+            pomodoro: 50,
+            shortBreak: 5,
+            longBreak: 79,
+            soundEnabled: false,
+            normalized: true
+        });
+        expect(result.fieldResults.shortBreak.displayValue).toBe("5");
+    });
+
+    it("returns the first invalid field when pomodoro is blank", () => {
+        const result = validateSettingsDraftValues({
+            pomodoro: "",
+            shortBreak: "5",
+            longBreak: "15",
+            soundEnabled: true
+        }, buildFieldConfig());
+
+        expect(result.isValid).toBe(false);
+        expect(result.invalidKey).toBe("pomodoro");
+        expect(result.message).toBe("Pomodoro must be between 1 and 120.");
+    });
+
+    it("returns the first invalid field when short break exceeds the maximum", () => {
+        const result = validateSettingsDraftValues({
+            pomodoro: "25",
+            shortBreak: "31",
+            longBreak: "15",
+            soundEnabled: true
+        }, buildFieldConfig());
+
+        expect(result.isValid).toBe(false);
+        expect(result.invalidKey).toBe("shortBreak");
+        expect(result.message).toBe("Short break must be between 1 and 30.");
+    });
+
+    it("returns the first invalid field when long break is blank", () => {
+        const result = validateSettingsDraftValues({
+            pomodoro: "25",
+            shortBreak: "5",
+            longBreak: "",
+            soundEnabled: true
+        }, buildFieldConfig());
+
+        expect(result.isValid).toBe(false);
+        expect(result.invalidKey).toBe("longBreak");
+        expect(result.message).toBe("Long break must be between 1 and 80.");
+    });
+
+    it("defaults soundEnabled to true when the draft omits it", () => {
+        const result = validateSettingsDraftValues({
+            pomodoro: "25",
+            shortBreak: "5",
+            longBreak: "15"
+        }, buildFieldConfig());
+
+        expect(result.isValid).toBe(true);
+        expect(result.draft.soundEnabled).toBe(true);
+    });
+});

--- a/tests/unit/settings-validation.spec.js
+++ b/tests/unit/settings-validation.spec.js
@@ -3,6 +3,7 @@ import settingsValidation from "../../js/settings-validation.js";
 
 const {
     DEFAULT_SETTINGS,
+    DECIMAL_MINUTES_PATTERN,
     FIELD_LIMITS,
     buildFieldConfig,
     normalizeMinuteValue,
@@ -50,6 +51,8 @@ describe("settings-validation", () => {
         expect(FIELD_LIMITS.pomodoro.max).toBe(120);
         expect(FIELD_LIMITS.shortBreak.max).toBe(30);
         expect(FIELD_LIMITS.longBreak.max).toBe(80);
+        expect(DECIMAL_MINUTES_PATTERN.test("12.5")).toBe(true);
+        expect(DECIMAL_MINUTES_PATTERN.test("1e2")).toBe(false);
     });
 
     it("accepts valid integer values unchanged", () => {
@@ -70,19 +73,21 @@ describe("settings-validation", () => {
         });
     });
 
-    it("defaults zero and negative values back to each field default", () => {
+    it("defaults zero values back to each field default", () => {
         expect(normalizeMinuteValue("0", buildFieldConfig()[0])).toEqual({
             value: 25,
             isValid: true,
             displayValue: "25",
             reason: "below-min-defaulted"
         });
+    });
 
+    it("rejects negative values instead of silently defaulting them", () => {
         expect(normalizeMinuteValue("-8", buildFieldConfig()[1])).toEqual({
-            value: 5,
-            isValid: true,
-            displayValue: "5",
-            reason: "below-min-defaulted"
+            value: null,
+            isValid: false,
+            displayValue: "-8",
+            reason: "invalid-format"
         });
     });
 
@@ -100,7 +105,23 @@ describe("settings-validation", () => {
             value: null,
             isValid: false,
             displayValue: "abc",
-            reason: "non-numeric"
+            reason: "invalid-format"
+        });
+    });
+
+    it("rejects scientific and hexadecimal number formats", () => {
+        expect(normalizeMinuteValue("1e2", buildFieldConfig()[0])).toEqual({
+            value: null,
+            isValid: false,
+            displayValue: "1e2",
+            reason: "invalid-format"
+        });
+
+        expect(normalizeMinuteValue("0x10", buildFieldConfig()[0])).toEqual({
+            value: null,
+            isValid: false,
+            displayValue: "0x10",
+            reason: "invalid-format"
         });
     });
 

--- a/tests/unit/timer-state.spec.js
+++ b/tests/unit/timer-state.spec.js
@@ -24,6 +24,36 @@ describe("timer-state", () => {
         });
     });
 
+    it("defaults zero, negative, and missing settings values", () => {
+        expect(timerState.normalizeSettings({
+            pomodoro: 0,
+            shortBreak: -3,
+            longBreak: undefined
+        })).toEqual({
+            pomodoro: 25,
+            shortBreak: 5,
+            longBreak: 15,
+            soundEnabled: true
+        });
+    });
+
+    it("maps modes to the correct settings keys and durations", () => {
+        const settings = {
+            pomodoro: 45,
+            shortBreak: 8,
+            longBreak: 30,
+            soundEnabled: true
+        };
+
+        expect(timerState.getSettingsKey("pomodoro")).toBe("pomodoro");
+        expect(timerState.getSettingsKey("short-break")).toBe("shortBreak");
+        expect(timerState.getSettingsKey("long-break")).toBe("longBreak");
+        expect(timerState.getSettingsKey("unexpected")).toBe("pomodoro");
+        expect(timerState.getModeDurationSeconds(settings, "pomodoro")).toBe(45 * 60);
+        expect(timerState.getModeDurationSeconds(settings, "short-break")).toBe(8 * 60);
+        expect(timerState.getModeDurationSeconds(settings, "long-break")).toBe(30 * 60);
+    });
+
     it("normalizes timer state with fallback mode and remaining time", () => {
         const settings = { pomodoro: 10, shortBreak: 3, longBreak: 20, soundEnabled: true };
 
@@ -39,6 +69,22 @@ describe("timer-state", () => {
             endTime: null,
             remainingSeconds: 10 * 60,
             completedPomodorosInCycle: 4
+        });
+    });
+
+    it("clears stale endTime values when the timer is paused", () => {
+        expect(timerState.normalizeTimerState({
+            currentMode: "short-break",
+            isRunning: false,
+            endTime: Date.now() + 100_000,
+            remainingSeconds: 55,
+            completedPomodorosInCycle: -99
+        }, timerState.getDefaultSettings())).toEqual({
+            currentMode: "short-break",
+            isRunning: false,
+            endTime: null,
+            remainingSeconds: 55,
+            completedPomodorosInCycle: 0
         });
     });
 
@@ -75,6 +121,7 @@ describe("timer-state", () => {
     });
 
     it("falls back to defaults when saved settings JSON is malformed", () => {
+        vi.spyOn(console, "warn").mockImplementation(() => {});
         localStorage.setItem(timerState.keys.SETTINGS_KEY, "{broken");
         expect(timerState.loadSettings()).toEqual(timerState.getDefaultSettings());
     });
@@ -128,6 +175,23 @@ describe("timer-state", () => {
         expect(started.remainingSeconds).toBe(5 * 60);
     });
 
+    it("returns the existing running timer state unchanged when start is pressed again", () => {
+        const now = 121_000;
+        expect(timerState.startTimerState({
+            currentMode: "pomodoro",
+            isRunning: true,
+            endTime: now + 55_000,
+            remainingSeconds: 55,
+            completedPomodorosInCycle: 2
+        }, timerState.getDefaultSettings(), now)).toEqual({
+            currentMode: "pomodoro",
+            isRunning: true,
+            endTime: now + 55_000,
+            remainingSeconds: 55,
+            completedPomodorosInCycle: 2
+        });
+    });
+
     it("pauses a running timer using the live remaining time", () => {
         const now = 200_000;
         const paused = timerState.pauseTimerState({
@@ -141,6 +205,22 @@ describe("timer-state", () => {
         expect(paused.isRunning).toBe(false);
         expect(paused.endTime).toBe(null);
         expect(paused.remainingSeconds).toBe(19);
+    });
+
+    it("keeps a paused timer paused when pause is requested again", () => {
+        expect(timerState.pauseTimerState({
+            currentMode: "long-break",
+            isRunning: false,
+            endTime: 999_999,
+            remainingSeconds: 88,
+            completedPomodorosInCycle: 4
+        }, timerState.getDefaultSettings(), 500_000)).toEqual({
+            currentMode: "long-break",
+            isRunning: false,
+            endTime: null,
+            remainingSeconds: 88,
+            completedPomodorosInCycle: 4
+        });
     });
 
     it("hydrates pomodoro completion into short break", () => {
@@ -162,6 +242,22 @@ describe("timer-state", () => {
         expect(hydrated.isRunning).toBe(true);
         expect(hydrated.completedPomodorosInCycle).toBe(1);
         expect(hydrated.remainingSeconds).toBe(5 * 60 - 1);
+    });
+
+    it("hydrates a paused timer without changing its mode or remaining time", () => {
+        expect(timerState.hydrateTimerState({
+            currentMode: "short-break",
+            isRunning: false,
+            endTime: Date.now() + 15_000,
+            remainingSeconds: 42,
+            completedPomodorosInCycle: 1
+        }, timerState.getDefaultSettings(), Date.now())).toEqual({
+            currentMode: "short-break",
+            isRunning: false,
+            endTime: null,
+            remainingSeconds: 42,
+            completedPomodorosInCycle: 1
+        });
     });
 
     it("hydrates across multiple elapsed segments into the correct later pomodoro", () => {
@@ -293,10 +389,30 @@ describe("timer-state", () => {
             completedPomodorosInCycle: 1
         });
 
+        vi.spyOn(console, "warn").mockImplementation(() => {});
         localStorage.setItem(timerState.keys.TIMER_STATE_KEY, "{bad");
         expect(timerState.loadTimerState(timerState.getDefaultSettings())).toEqual(
             timerState.getDefaultTimerState(timerState.getDefaultSettings())
         );
+    });
+
+    it("hydrates stored running timer state when loading from localStorage", () => {
+        vi.spyOn(Date, "now").mockReturnValue(1_000_000);
+        localStorage.setItem(timerState.keys.TIMER_STATE_KEY, JSON.stringify({
+            currentMode: "pomodoro",
+            isRunning: true,
+            endTime: 1_020_000,
+            remainingSeconds: 25 * 60,
+            completedPomodorosInCycle: 0
+        }));
+
+        expect(timerState.loadTimerState(timerState.getDefaultSettings())).toEqual({
+            currentMode: "pomodoro",
+            isRunning: true,
+            endTime: 1_020_000,
+            remainingSeconds: 20,
+            completedPomodorosInCycle: 0
+        });
     });
 
     it("resets timer state using saved settings when explicit settings are absent", () => {
@@ -333,5 +449,12 @@ describe("timer-state", () => {
 
         expect(timerState.areStatesEqual(state, { ...state })).toBe(true);
         expect(timerState.areStatesEqual(state, { ...state, remainingSeconds: 455 })).toBe(false);
+    });
+
+    it("caps the displayed pomodoro number at the cycle maximum", () => {
+        expect(timerState.getCurrentPomodoroNumber({
+            currentMode: "pomodoro",
+            completedPomodorosInCycle: 99
+        })).toBe(4);
     });
 });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -3,6 +3,10 @@ const { defineConfig } = require("vitest/config");
 module.exports = defineConfig({
     test: {
         environment: "jsdom",
-        include: ["tests/unit/**/*.spec.js"]
+        include: ["tests/unit/**/*.spec.js"],
+        reporters: [
+            "default",
+            new (require("./tests/unit/explanation-reporter.cjs"))()
+        ]
     }
 });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,12 +1,15 @@
 const { defineConfig } = require("vitest/config");
+const showExplanations = process.env.TEST_EXPLANATIONS !== "0";
 
 module.exports = defineConfig({
     test: {
         environment: "jsdom",
         include: ["tests/unit/**/*.spec.js"],
-        reporters: [
-            "default",
-            new (require("./tests/unit/explanation-reporter.cjs"))()
-        ]
+        reporters: showExplanations
+            ? [
+                "default",
+                new (require("./tests/unit/explanation-reporter.cjs"))()
+            ]
+            : ["default"]
     }
 });


### PR DESCRIPTION
This pull request introduces robust validation and normalization for both timer settings and productivity (to-do/notes) fields, improves documentation, and ensures that only safe, well-formed data is stored and restored from `localStorage`. The main focus is on preventing invalid or malformed user input from breaking the UI or persisting bad data, while also making the validation logic reusable and testable. The README and manual test plan are updated to reflect these new rules and behaviors.

**Validation and Normalization Improvements**

* Added a new shared module `js/settings-validation.js` for validating and normalizing timer settings, including strict checks for allowed value ranges, input format, and defaulting/resetting logic. [[1]](diffhunk://#diff-a6015460a31a8f6d1068a3af5d961b3fc77c7342dec967171b230bf168e7620fR1-R150) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R134)
* Productivity store (`js/productivity-store.js`) now trims, validates, and caps to-do and note fields on both input and load, rejecting blank or excessively long entries and normalizing malformed data from storage. [[1]](diffhunk://#diff-4de1ec25619c3491269745645982e035825f66310b1bbfc925b68b53a1dc34edR3-R6) [[2]](diffhunk://#diff-4de1ec25619c3491269745645982e035825f66310b1bbfc925b68b53a1dc34edR33-R138) [[3]](diffhunk://#diff-4de1ec25619c3491269745645982e035825f66310b1bbfc925b68b53a1dc34edR174-R202)
* All productivity CRUD operations (create, update) now sanitize and validate payloads before saving, preventing invalid edits or additions. [[1]](diffhunk://#diff-4de1ec25619c3491269745645982e035825f66310b1bbfc925b68b53a1dc34edR174-R202) [[2]](diffhunk://#diff-4de1ec25619c3491269745645982e035825f66310b1bbfc925b68b53a1dc34edR219-R223)
* Productivity edit UIs now provide inline error messages for blank or invalid entries during editing, improving UX feedback. [[1]](diffhunk://#diff-7192f847663d2591dda7dca28e06007cda8377f4175c6fc494f2918c1fa4b051R160) [[2]](diffhunk://#diff-7192f847663d2591dda7dca28e06007cda8377f4175c6fc494f2918c1fa4b051R203) [[3]](diffhunk://#diff-7192f847663d2591dda7dca28e06007cda8377f4175c6fc494f2918c1fa4b051R295-R313)

**Documentation and Testing Updates**

* The `README.md` is rewritten to document all validation rules, data persistence guarantees, and technical structure, making it easier for contributors and users to understand app behavior and constraints.
* The manual test plan (`docs/testing/manual-test-plan.md`) is updated with new negative cases and normalization scenarios for both timer settings and productivity items, ensuring comprehensive coverage of edge cases. [[1]](diffhunk://#diff-d04e02fb2b7a09f23a7b1e417d2e83792dd0cffb48d0d7e22ac1d015f8df7fa6R38-R57) [[2]](diffhunk://#diff-d04e02fb2b7a09f23a7b1e417d2e83792dd0cffb48d0d7e22ac1d015f8df7fa6R72-R74)

These changes make the app more resilient to bad input, easier to maintain, and safer for users who may have corrupted or legacy data in their browsers.