### PR TITLE
Modularize JS, add tooling & refactor logic

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+VITE_APP_STATUS=Production

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ Gemfile.lock
 
 # Ignore node_modules directory which may be used for frontend dependencies
 node_modules/
+dist/
 playwright-report/
 test-results/
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+dist
+node_modules
+playwright-report
+test-results
+coverage

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "none"
+}

--- a/about.html
+++ b/about.html
@@ -86,12 +86,10 @@
                 &copy; 2026 Pomodoro Web |
                 <a href="https://github.com/docholypancake/pomodoroWeb/issues" class="footer-link">GitHub</a>
             </p>
-            <p class="footer-note">Stay focused, stay productive</p>
+            <p class="footer-note">Stay focused, stay productive | Mode: <span data-app-status>Unknown</span></p>
         </div>
     </footer>
 
-    <script src="js/sound.js"></script>
-    <script src="js/timer-state.js"></script>
-    <script src="js/mini-timer.js"></script>
+    <script type="module" src="js/entries/secondary-page.js"></script>
 </body>
 </html>

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,68 @@
+const js = require("@eslint/js");
+const globals = require("globals");
+
+const testGlobals = {
+    describe: "readonly",
+    it: "readonly",
+    test: "readonly",
+    expect: "readonly",
+    beforeAll: "readonly",
+    beforeEach: "readonly",
+    afterAll: "readonly",
+    afterEach: "readonly",
+    vi: "readonly"
+};
+
+module.exports = [
+    {
+        ignores: [
+            "dist/**",
+            "node_modules/**",
+            "playwright-report/**",
+            "test-results/**",
+            "coverage/**"
+        ]
+    },
+    js.configs.recommended,
+    {
+        files: ["js/**/*.js"],
+        languageOptions: {
+            sourceType: "module",
+            globals: {
+                ...globals.browser,
+                ...globals.worker
+            }
+        },
+        rules: {
+            "no-unused-vars": "error"
+        }
+    },
+    {
+        files: ["tests/unit/**/*.js"],
+        languageOptions: {
+            sourceType: "module",
+            globals: {
+                ...globals.browser,
+                ...globals.node,
+                ...testGlobals
+            }
+        }
+    },
+    {
+        files: [
+            "tests/e2e/**/*.js",
+            "tests/**/*.cjs",
+            "tests/server.js",
+            "*.config.js",
+            "*.config.cjs"
+        ],
+        languageOptions: {
+            sourceType: "commonjs",
+            globals: {
+                ...globals.node,
+                ...globals.browser,
+                ...testGlobals
+            }
+        }
+    }
+];

--- a/helpus.html
+++ b/helpus.html
@@ -66,12 +66,10 @@
                 &copy; 2026 Pomodoro Web |
                 <a href="https://github.com/docholypancake/pomodoroWeb/issues" class="footer-link">GitHub</a>
             </p>
-            <p class="footer-note">Stay focused, stay productive</p>
+            <p class="footer-note">Stay focused, stay productive | Mode: <span data-app-status>Unknown</span></p>
         </div>
     </footer>
 
-    <script src="js/sound.js"></script>
-    <script src="js/timer-state.js"></script>
-    <script src="js/mini-timer.js"></script>
+    <script type="module" src="js/entries/secondary-page.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -125,14 +125,10 @@
                 &copy; 2026 Pomodoro Web | Bug? Report on
                 <a href="https://github.com/docholypancake/pomodoroWeb/issues" class="footer-link">GitHub</a>
             </p>
-            <p class="footer-note">Stay focused, stay productive</p>
+            <p class="footer-note">Stay focused, stay productive | Mode: <span data-app-status>Unknown</span></p>
         </div>
     </footer>
 
-    <script src="js/sound.js"></script>
-    <script src="js/timer-state.js"></script>
-    <script src="js/settings-validation.js"></script>
-    <script src="js/settings.js"></script>
-    <script src="js/timer.js"></script>
+    <script type="module" src="js/entries/timer-page.js"></script>
 </body>
 </html>

--- a/js/app-status.js
+++ b/js/app-status.js
@@ -1,0 +1,5 @@
+const appStatus = import.meta.env?.VITE_APP_STATUS || "Unknown";
+
+document.querySelectorAll("[data-app-status]").forEach(element => {
+    element.textContent = appStatus;
+});

--- a/js/entries/productivity-page.js
+++ b/js/entries/productivity-page.js
@@ -1,0 +1,6 @@
+import "../sound.js";
+import "../timer-state.js";
+import "../productivity-store.js";
+import "../app-status.js";
+import "../mini-timer.js";
+import "../productivity.js";

--- a/js/entries/secondary-page.js
+++ b/js/entries/secondary-page.js
@@ -1,0 +1,4 @@
+import "../sound.js";
+import "../timer-state.js";
+import "../app-status.js";
+import "../mini-timer.js";

--- a/js/entries/timer-page.js
+++ b/js/entries/timer-page.js
@@ -1,0 +1,6 @@
+import "../sound.js";
+import "../timer-state.js";
+import "../settings-validation.js";
+import "../app-status.js";
+import "../settings.js";
+import "../timer.js";

--- a/js/mini-timer.js
+++ b/js/mini-timer.js
@@ -1,12 +1,13 @@
+import timerStateStore from "./timer-state.js";
+import soundManager from "./sound.js";
+
 document.addEventListener("DOMContentLoaded", () => {
-    const timerStateStore = window.PomodoroTimerState;
-    const soundManager = window.PomodoroSoundManager;
     const miniTimer = document.getElementById("miniTimer");
     const miniTimerMode = document.getElementById("miniTimerMode");
     const miniTimerTime = document.getElementById("miniTimerTime");
     const miniTimerStatus = document.getElementById("miniTimerStatus");
 
-    if (!timerStateStore || !miniTimer || !miniTimerMode || !miniTimerTime || !miniTimerStatus) return;
+    if (!miniTimer || !miniTimerMode || !miniTimerTime || !miniTimerStatus) return;
 
     const timerModeClasses = [
         "mini-timer--pomodoro",
@@ -25,7 +26,7 @@ document.addEventListener("DOMContentLoaded", () => {
     let timerState = timerStateStore.loadTimerState(settings);
 
     function playSound(fileName) {
-        soundManager?.play(fileName, settings.soundEnabled);
+        soundManager.play(fileName, settings.soundEnabled);
     }
 
     function formatTime(totalSeconds) {
@@ -112,18 +113,18 @@ document.addEventListener("DOMContentLoaded", () => {
         }
     }
 
-    document.addEventListener("settings:updated", (event) => {
+    document.addEventListener("settings:updated", event => {
         settings = event.detail;
         const nextState = timerStateStore.applySettingsToTimerState(timerState, settings);
         applyIncomingState(nextState, settings, false);
         timerState = timerStateStore.saveTimerState(timerState, settings);
     });
 
-    document.addEventListener("timer:state-updated", (event) => {
+    document.addEventListener("timer:state-updated", event => {
         applyIncomingState(event.detail.state, event.detail.settings, true);
     });
 
-    window.addEventListener("storage", (event) => {
+    window.addEventListener("storage", event => {
         let nextSettings = settings;
         if (event.key === timerStateStore.keys.SETTINGS_KEY) {
             nextSettings = timerStateStore.loadSettings();

--- a/js/productivity-store.js
+++ b/js/productivity-store.js
@@ -1,235 +1,231 @@
-(function (globalScope) {
-    const STORAGE_KEY = "pomodoroProductivity.v1";
-    const ITEM_LIMITS = {
-        todo: 160,
-        notes: 1200
+const STORAGE_KEY = "pomodoroProductivity.v1";
+const ITEM_LIMITS = {
+    todo: 160,
+    notes: 1200
+};
+
+function createId() {
+    if (globalThis?.crypto?.randomUUID) {
+        return globalThis.crypto.randomUUID();
+    }
+
+    return `item-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function isValidTimestamp(value) {
+    if (typeof value !== "string") return false;
+    return !Number.isNaN(new Date(value).getTime());
+}
+
+function getIsoNow(nowProvider = () => new Date()) {
+    const value = nowProvider();
+    return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+function emptyState() {
+    return {
+        todo: [],
+        notes: []
     };
+}
 
-    function createId() {
-        if (globalScope?.crypto?.randomUUID) {
-            return globalScope.crypto.randomUUID();
-        }
+function sanitizeTextValue(value, maxLength) {
+    if (typeof value !== "string") return null;
 
-        return `item-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const trimmedValue = value.trim();
+    if (!trimmedValue) return null;
+
+    return trimmedValue.slice(0, maxLength);
+}
+
+function normalizeTodoItem(item, fallbackTimestamp) {
+    const text = sanitizeTextValue(item?.text, ITEM_LIMITS.todo);
+    if (!item || typeof item.id !== "string" || !text) {
+        return null;
     }
 
-    function isValidTimestamp(value) {
-        if (typeof value !== "string") return false;
-        return !Number.isNaN(new Date(value).getTime());
+    return {
+        id: item.id,
+        text,
+        completed: Boolean(item.completed),
+        createdAt: isValidTimestamp(item.createdAt) ? item.createdAt : fallbackTimestamp,
+        updatedAt: isValidTimestamp(item.updatedAt) ? item.updatedAt : fallbackTimestamp
+    };
+}
+
+function normalizeNoteItem(item, fallbackTimestamp) {
+    const content = sanitizeTextValue(item?.content, ITEM_LIMITS.notes);
+    if (!item || typeof item.id !== "string" || !content) {
+        return null;
     }
 
-    function getIsoNow(nowProvider = () => new Date()) {
-        const value = nowProvider();
-        return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
-    }
+    return {
+        id: item.id,
+        content,
+        createdAt: isValidTimestamp(item.createdAt) ? item.createdAt : fallbackTimestamp,
+        updatedAt: isValidTimestamp(item.updatedAt) ? item.updatedAt : fallbackTimestamp
+    };
+}
 
-    function emptyState() {
+function sanitizeCreatePayload(type, payload) {
+    if (type === "todo") {
+        const text = sanitizeTextValue(payload?.text, ITEM_LIMITS.todo);
+        if (!text) return null;
+
         return {
-            todo: [],
-            notes: []
-        };
-    }
-
-    function sanitizeTextValue(value, maxLength) {
-        if (typeof value !== "string") return null;
-
-        const trimmedValue = value.trim();
-        if (!trimmedValue) return null;
-
-        return trimmedValue.slice(0, maxLength);
-    }
-
-    function normalizeTodoItem(item, fallbackTimestamp) {
-        const text = sanitizeTextValue(item?.text, ITEM_LIMITS.todo);
-        if (!item || typeof item.id !== "string" || !text) {
-            return null;
-        }
-
-        return {
-            id: item.id,
             text,
-            completed: Boolean(item.completed),
-            createdAt: isValidTimestamp(item.createdAt) ? item.createdAt : fallbackTimestamp,
-            updatedAt: isValidTimestamp(item.updatedAt) ? item.updatedAt : fallbackTimestamp
+            completed: Boolean(payload?.completed)
         };
     }
 
-    function normalizeNoteItem(item, fallbackTimestamp) {
-        const content = sanitizeTextValue(item?.content, ITEM_LIMITS.notes);
-        if (!item || typeof item.id !== "string" || !content) {
+    if (type === "notes") {
+        const content = sanitizeTextValue(payload?.content, ITEM_LIMITS.notes);
+        if (!content) return null;
+
+        return { content };
+    }
+
+    return null;
+}
+
+function sanitizeUpdateChanges(type, changes) {
+    if (!changes || typeof changes !== "object") return null;
+
+    if (type === "todo") {
+        const nextChanges = {};
+
+        if (Object.prototype.hasOwnProperty.call(changes, "text")) {
+            const text = sanitizeTextValue(changes.text, ITEM_LIMITS.todo);
+            if (!text) return null;
+            nextChanges.text = text;
+        }
+
+        if (Object.prototype.hasOwnProperty.call(changes, "completed")) {
+            nextChanges.completed = Boolean(changes.completed);
+        }
+
+        return Object.keys(nextChanges).length ? nextChanges : null;
+    }
+
+    if (type === "notes") {
+        if (!Object.prototype.hasOwnProperty.call(changes, "content")) {
             return null;
         }
 
-        return {
-            id: item.id,
-            content,
-            createdAt: isValidTimestamp(item.createdAt) ? item.createdAt : fallbackTimestamp,
-            updatedAt: isValidTimestamp(item.updatedAt) ? item.updatedAt : fallbackTimestamp
-        };
+        const content = sanitizeTextValue(changes.content, ITEM_LIMITS.notes);
+        if (!content) return null;
+
+        return { content };
     }
 
-    function sanitizeCreatePayload(type, payload) {
-        if (type === "todo") {
-            const text = sanitizeTextValue(payload?.text, ITEM_LIMITS.todo);
-            if (!text) return null;
+    return null;
+}
 
-            return {
-                text,
-                completed: Boolean(payload?.completed)
-            };
-        }
+function normalizeProductivityState(rawState, nowProvider = () => new Date()) {
+    const fallbackTimestamp = getIsoNow(nowProvider);
+    const safeState = emptyState();
 
-        if (type === "notes") {
-            const content = sanitizeTextValue(payload?.content, ITEM_LIMITS.notes);
-            if (!content) return null;
+    safeState.todo = Array.isArray(rawState?.todo)
+        ? rawState.todo
+            .map(item => normalizeTodoItem(item, fallbackTimestamp))
+            .filter(Boolean)
+        : [];
 
-            return { content };
-        }
+    safeState.notes = Array.isArray(rawState?.notes)
+        ? rawState.notes
+            .map(item => normalizeNoteItem(item, fallbackTimestamp))
+            .filter(Boolean)
+        : [];
 
-        return null;
-    }
+    return safeState;
+}
 
-    function sanitizeUpdateChanges(type, changes) {
-        if (!changes || typeof changes !== "object") return null;
+function createProductivityStore(storage = globalThis?.localStorage, options = {}) {
+    const key = options.key || STORAGE_KEY;
+    const nowProvider = options.nowProvider || (() => new Date());
+    const idFactory = options.idFactory || createId;
 
-        if (type === "todo") {
-            const nextChanges = {};
-
-            if (Object.prototype.hasOwnProperty.call(changes, "text")) {
-                const text = sanitizeTextValue(changes.text, ITEM_LIMITS.todo);
-                if (!text) return null;
-                nextChanges.text = text;
-            }
-
-            if (Object.prototype.hasOwnProperty.call(changes, "completed")) {
-                nextChanges.completed = Boolean(changes.completed);
-            }
-
-            return Object.keys(nextChanges).length ? nextChanges : null;
-        }
-
-        if (type === "notes") {
-            if (!Object.prototype.hasOwnProperty.call(changes, "content")) {
-                return null;
-            }
-
-            const content = sanitizeTextValue(changes.content, ITEM_LIMITS.notes);
-            if (!content) return null;
-
-            return { content };
-        }
-
-        return null;
-    }
-
-    function normalizeProductivityState(rawState, nowProvider = () => new Date()) {
-        const fallbackTimestamp = getIsoNow(nowProvider);
-        const safeState = emptyState();
-
-        safeState.todo = Array.isArray(rawState?.todo)
-            ? rawState.todo
-                .map(item => normalizeTodoItem(item, fallbackTimestamp))
-                .filter(Boolean)
-            : [];
-
-        safeState.notes = Array.isArray(rawState?.notes)
-            ? rawState.notes
-                .map(item => normalizeNoteItem(item, fallbackTimestamp))
-                .filter(Boolean)
-            : [];
-
-        return safeState;
-    }
-
-    function createProductivityStore(storage = globalScope?.localStorage, options = {}) {
-        const key = options.key || STORAGE_KEY;
-        const nowProvider = options.nowProvider || (() => new Date());
-        const idFactory = options.idFactory || createId;
-
-        return {
-            key,
-            emptyState,
-            normalize(rawState) {
-                return normalizeProductivityState(rawState, nowProvider);
-            },
-            load() {
-                try {
-                    const storedValue = storage?.getItem(key);
-                    if (!storedValue) {
-                        return emptyState();
-                    }
-
-                    return normalizeProductivityState(JSON.parse(storedValue), nowProvider);
-                } catch (error) {
+    return {
+        key,
+        emptyState,
+        normalize(rawState) {
+            return normalizeProductivityState(rawState, nowProvider);
+        },
+        load() {
+            try {
+                const storedValue = storage?.getItem(key);
+                if (!storedValue) {
                     return emptyState();
                 }
-            },
-            save(nextState) {
-                const normalizedState = normalizeProductivityState(nextState, nowProvider);
-                storage?.setItem(key, JSON.stringify(normalizedState));
-                return normalizedState;
-            },
-            create(type, payload) {
-                const state = this.load();
-                const sanitizedPayload = sanitizeCreatePayload(type, payload);
-                if (!sanitizedPayload || !Array.isArray(state[type])) {
-                    return state[type] || [];
-                }
 
-                const now = getIsoNow(nowProvider);
-                const nextItem = {
-                    id: idFactory(),
-                    createdAt: now,
-                    updatedAt: now,
-                    ...sanitizedPayload
-                };
-
-                state[type] = [nextItem, ...state[type]];
-                return this.save(state)[type];
-            },
-            update(type, itemId, changes) {
-                const state = this.load();
-                const sanitizedChanges = sanitizeUpdateChanges(type, changes);
-                if (!sanitizedChanges || !Array.isArray(state[type])) {
-                    return state[type] || [];
-                }
-
-                state[type] = state[type].map(item => {
-                    if (item.id !== itemId) return item;
-
-                    return {
-                        ...item,
-                        ...sanitizedChanges,
-                        updatedAt: getIsoNow(nowProvider)
-                    };
-                });
-
-                return this.save(state)[type];
-            },
-            delete(type, itemId) {
-                const state = this.load();
-                state[type] = state[type].filter(item => item.id !== itemId);
-                return this.save(state)[type];
+                return normalizeProductivityState(JSON.parse(storedValue), nowProvider);
+            } catch {
+                return emptyState();
             }
-        };
-    }
+        },
+        save(nextState) {
+            const normalizedState = normalizeProductivityState(nextState, nowProvider);
+            storage?.setItem(key, JSON.stringify(normalizedState));
+            return normalizedState;
+        },
+        create(type, payload) {
+            const state = this.load();
+            const sanitizedPayload = sanitizeCreatePayload(type, payload);
+            if (!sanitizedPayload || !Array.isArray(state[type])) {
+                return state[type] || [];
+            }
 
-    const api = {
-        STORAGE_KEY,
-        ITEM_LIMITS,
-        createId,
-        isValidTimestamp,
-        emptyState,
-        sanitizeTextValue,
-        normalizeProductivityState,
-        createProductivityStore
+            const now = getIsoNow(nowProvider);
+            const nextItem = {
+                id: idFactory(),
+                createdAt: now,
+                updatedAt: now,
+                ...sanitizedPayload
+            };
+
+            state[type] = [nextItem, ...state[type]];
+            return this.save(state)[type];
+        },
+        update(type, itemId, changes) {
+            const state = this.load();
+            const sanitizedChanges = sanitizeUpdateChanges(type, changes);
+            if (!sanitizedChanges || !Array.isArray(state[type])) {
+                return state[type] || [];
+            }
+
+            state[type] = state[type].map(item => {
+                if (item.id !== itemId) return item;
+
+                return {
+                    ...item,
+                    ...sanitizedChanges,
+                    updatedAt: getIsoNow(nowProvider)
+                };
+            });
+
+            return this.save(state)[type];
+        },
+        delete(type, itemId) {
+            const state = this.load();
+            state[type] = state[type].filter(item => item.id !== itemId);
+            return this.save(state)[type];
+        }
     };
+}
 
-    if (globalScope) {
-        globalScope.PomodoroProductivityStore = api;
-    }
+const api = {
+    STORAGE_KEY,
+    ITEM_LIMITS,
+    createId,
+    isValidTimestamp,
+    emptyState,
+    sanitizeTextValue,
+    normalizeProductivityState,
+    createProductivityStore
+};
 
-    if (typeof module !== "undefined" && module.exports) {
-        module.exports = api;
-    }
-})(typeof window !== "undefined" ? window : globalThis);
+if (typeof window !== "undefined") {
+    window.PomodoroProductivityStore = api;
+}
+
+export default api;

--- a/js/settings-validation.js
+++ b/js/settings-validation.js
@@ -1,150 +1,147 @@
-(function (globalScope) {
-    const DEFAULT_SETTINGS = {
-        pomodoro: 25,
-        shortBreak: 5,
-        longBreak: 15,
-        soundEnabled: true
-    };
+const DEFAULT_SETTINGS = {
+    pomodoro: 25,
+    shortBreak: 5,
+    longBreak: 15,
+    soundEnabled: true
+};
 
-    const FIELD_LIMITS = {
-        pomodoro: {
-            key: "pomodoro",
-            label: "Pomodoro",
-            min: 1,
-            max: 120
-        },
-        shortBreak: {
-            key: "shortBreak",
-            label: "Short break",
-            min: 1,
-            max: 30
-        },
-        longBreak: {
-            key: "longBreak",
-            label: "Long break",
-            min: 1,
-            max: 80
-        }
-    };
-    const DECIMAL_MINUTES_PATTERN = /^\d+(?:\.\d+)?$/;
+const FIELD_LIMITS = {
+    pomodoro: {
+        key: "pomodoro",
+        label: "Pomodoro",
+        min: 1,
+        max: 120
+    },
+    shortBreak: {
+        key: "shortBreak",
+        label: "Short break",
+        min: 1,
+        max: 30
+    },
+    longBreak: {
+        key: "longBreak",
+        label: "Long break",
+        min: 1,
+        max: 80
+    }
+};
 
-    function buildFieldConfig(defaultSettings = DEFAULT_SETTINGS) {
-        return Object.values(FIELD_LIMITS).map(field => ({
-            ...field,
-            defaultValue: Number(defaultSettings?.[field.key]) || DEFAULT_SETTINGS[field.key]
-        }));
+const DECIMAL_MINUTES_PATTERN = /^\d+(?:\.\d+)?$/;
+
+function buildFieldConfig(defaultSettings = DEFAULT_SETTINGS) {
+    return Object.values(FIELD_LIMITS).map(field => ({
+        ...field,
+        defaultValue: Number(defaultSettings?.[field.key]) || DEFAULT_SETTINGS[field.key]
+    }));
+}
+
+function normalizeMinuteValue(rawValue, config) {
+    const trimmedValue = String(rawValue ?? "").trim();
+
+    if (trimmedValue === "") {
+        return {
+            value: null,
+            isValid: false,
+            displayValue: "",
+            reason: "blank"
+        };
     }
 
-    function normalizeMinuteValue(rawValue, config) {
-        const trimmedValue = String(rawValue ?? "").trim();
+    if (!DECIMAL_MINUTES_PATTERN.test(trimmedValue)) {
+        return {
+            value: null,
+            isValid: false,
+            displayValue: trimmedValue,
+            reason: "invalid-format"
+        };
+    }
 
-        if (trimmedValue === "") {
-            return {
-                value: null,
-                isValid: false,
-                displayValue: "",
-                reason: "blank"
-            };
-        }
+    const numericValue = Number(trimmedValue);
+    const flooredValue = Math.floor(numericValue);
 
-        if (!DECIMAL_MINUTES_PATTERN.test(trimmedValue)) {
-            return {
-                value: null,
-                isValid: false,
-                displayValue: trimmedValue,
-                reason: "invalid-format"
-            };
-        }
+    if (flooredValue === 0) {
+        return {
+            value: config.defaultValue,
+            isValid: true,
+            displayValue: String(config.defaultValue),
+            reason: "below-min-defaulted"
+        };
+    }
 
-        const numericValue = Number(trimmedValue);
-        const flooredValue = Math.floor(numericValue);
-
-        if (flooredValue === 0) {
-            return {
-                value: config.defaultValue,
-                isValid: true,
-                displayValue: String(config.defaultValue),
-                reason: "below-min-defaulted"
-            };
-        }
-
-        if (flooredValue < config.min) {
-            return {
-                value: flooredValue,
-                isValid: false,
-                displayValue: String(flooredValue),
-                reason: "below-min"
-            };
-        }
-
-        if (flooredValue > config.max) {
-            return {
-                value: flooredValue,
-                isValid: false,
-                displayValue: String(flooredValue),
-                reason: "above-max"
-            };
-        }
-
+    if (flooredValue < config.min) {
         return {
             value: flooredValue,
-            isValid: true,
+            isValid: false,
             displayValue: String(flooredValue),
-            reason: Number.isInteger(numericValue) ? "valid" : "floored"
+            reason: "below-min"
         };
     }
 
-    function validateSettingsDraftValues(rawValues, fieldConfigs, normalizeSettings = value => value) {
-        const draft = {
-            soundEnabled: rawValues?.soundEnabled !== false
+    if (flooredValue > config.max) {
+        return {
+            value: flooredValue,
+            isValid: false,
+            displayValue: String(flooredValue),
+            reason: "above-max"
         };
-        const fieldResults = {};
+    }
 
-        for (const config of fieldConfigs) {
-            const normalizedField = normalizeMinuteValue(rawValues?.[config.key], config);
-            fieldResults[config.key] = normalizedField;
+    return {
+        value: flooredValue,
+        isValid: true,
+        displayValue: String(flooredValue),
+        reason: Number.isInteger(numericValue) ? "valid" : "floored"
+    };
+}
 
-            if (
-                !normalizedField.isValid
-                || !Number.isInteger(normalizedField.value)
-                || normalizedField.value < config.min
-                || normalizedField.value > config.max
-            ) {
-                return {
-                    isValid: false,
-                    draft: null,
-                    invalidKey: config.key,
-                    message: `${config.label} must be between ${config.min} and ${config.max}.`,
-                    fieldResults
-                };
-            }
+function validateSettingsDraftValues(rawValues, fieldConfigs, normalizeSettings = value => value) {
+    const draft = {
+        soundEnabled: rawValues?.soundEnabled !== false
+    };
+    const fieldResults = {};
 
-            draft[config.key] = normalizedField.value;
+    for (const config of fieldConfigs) {
+        const normalizedField = normalizeMinuteValue(rawValues?.[config.key], config);
+        fieldResults[config.key] = normalizedField;
+
+        if (
+            !normalizedField.isValid
+            || !Number.isInteger(normalizedField.value)
+            || normalizedField.value < config.min
+            || normalizedField.value > config.max
+        ) {
+            return {
+                isValid: false,
+                draft: null,
+                invalidKey: config.key,
+                message: `${config.label} must be between ${config.min} and ${config.max}.`,
+                fieldResults
+            };
         }
 
-        return {
-            isValid: true,
-            draft: normalizeSettings(draft),
-            invalidKey: null,
-            message: "",
-            fieldResults
-        };
+        draft[config.key] = normalizedField.value;
     }
 
-    const api = {
-        DEFAULT_SETTINGS,
-        FIELD_LIMITS,
-        DECIMAL_MINUTES_PATTERN,
-        buildFieldConfig,
-        normalizeMinuteValue,
-        validateSettingsDraftValues
+    return {
+        isValid: true,
+        draft: normalizeSettings(draft),
+        invalidKey: null,
+        message: "",
+        fieldResults
     };
+}
 
-    if (globalScope) {
-        globalScope.PomodoroSettingsValidation = api;
-    }
+const api = {
+    DEFAULT_SETTINGS,
+    FIELD_LIMITS,
+    DECIMAL_MINUTES_PATTERN,
+    buildFieldConfig,
+    normalizeMinuteValue,
+    validateSettingsDraftValues
+};
 
-    if (typeof module !== "undefined" && module.exports) {
-        module.exports = api;
-    }
-})(typeof window !== "undefined" ? window : globalThis);
+if (typeof window !== "undefined") {
+    window.PomodoroSettingsValidation = api;
+}
+
+export default api;

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,3 +1,6 @@
+import timerStateStore from "./timer-state.js";
+import settingsValidationApi from "./settings-validation.js";
+
 const settingsToggle = document.getElementById("settingsToggle");
 const timerSection = document.getElementById("timerSection");
 const settingsSection = document.getElementById("settingsSection");
@@ -10,24 +13,9 @@ const longBreakInput = document.getElementById("longBreakTime");
 const soundEnabledInput = document.getElementById("soundEnabled");
 const settingsError = document.getElementById("settingsError");
 
-const timerStateStore = window.PomodoroTimerState;
-const settingsValidationApi = window.PomodoroSettingsValidation;
-const defaultSettings = timerStateStore ? timerStateStore.getDefaultSettings() : {
-    pomodoro: 25,
-    shortBreak: 5,
-    longBreak: 15,
-    soundEnabled: true
-};
+const defaultSettings = timerStateStore.getDefaultSettings();
 
-const fieldConfig = (
-    settingsValidationApi
-        ? settingsValidationApi.buildFieldConfig(defaultSettings)
-        : [
-            { key: "pomodoro", label: "Pomodoro", min: 1, max: 120, defaultValue: defaultSettings.pomodoro },
-            { key: "shortBreak", label: "Short break", min: 1, max: 30, defaultValue: defaultSettings.shortBreak },
-            { key: "longBreak", label: "Long break", min: 1, max: 80, defaultValue: defaultSettings.longBreak }
-        ]
-).map(config => ({
+const fieldConfig = settingsValidationApi.buildFieldConfig(defaultSettings).map(config => ({
     ...config,
     input: {
         pomodoro: pomodoroInput,
@@ -39,12 +27,7 @@ const fieldConfig = (
 let savedSettings = loadSettingsFromStorage();
 
 function loadSettingsFromStorage() {
-    return timerStateStore ? timerStateStore.loadSettings() : {
-        pomodoro: 25,
-        shortBreak: 5,
-        longBreak: 15,
-        soundEnabled: true
-    };
+    return timerStateStore.loadSettings();
 }
 
 function applySettingsToInputs(settings) {
@@ -79,34 +62,9 @@ function showValidationError(message, invalidInputs) {
 }
 
 function normalizeMinuteInputValue(input, config) {
-    if (settingsValidationApi) {
-        const normalized = settingsValidationApi.normalizeMinuteValue(input.value, config);
-        input.value = normalized.displayValue;
-        return normalized;
-    }
-
-    const rawValue = input.value.trim();
-    if (rawValue === "") {
-        return { value: null, isValid: false, displayValue: "" };
-    }
-
-    const numericValue = Number(rawValue);
-    if (!Number.isFinite(numericValue)) {
-        return { value: null, isValid: false, displayValue: rawValue };
-    }
-
-    const flooredValue = Math.floor(numericValue);
-    if (flooredValue < config.min) {
-        input.value = String(config.defaultValue);
-        return { value: config.defaultValue, isValid: true, displayValue: String(config.defaultValue) };
-    }
-
-    input.value = String(flooredValue);
-    if (flooredValue > config.max) {
-        return { value: flooredValue, isValid: false, displayValue: String(flooredValue) };
-    }
-
-    return { value: flooredValue, isValid: true, displayValue: String(flooredValue) };
+    const normalized = settingsValidationApi.normalizeMinuteValue(input.value, config);
+    input.value = normalized.displayValue;
+    return normalized;
 }
 
 function validateSettingsDraft() {
@@ -118,50 +76,29 @@ function validateSettingsDraft() {
         soundEnabled: soundEnabledInput.checked
     };
 
-    if (settingsValidationApi && timerStateStore) {
-        const validation = settingsValidationApi.validateSettingsDraftValues(
-            rawDraft,
-            fieldConfig,
-            timerStateStore.normalizeSettings
-        );
+    const validation = settingsValidationApi.validateSettingsDraftValues(
+        rawDraft,
+        fieldConfig,
+        timerStateStore.normalizeSettings
+    );
 
-        fieldConfig.forEach(config => {
-            const normalizedField = validation.fieldResults?.[config.key];
-            if (normalizedField && typeof normalizedField.displayValue === "string") {
-                config.input.value = normalizedField.displayValue;
-            }
-        });
-
-        if (!validation.isValid) {
-            const invalidField = fieldConfig.find(config => config.key === validation.invalidKey);
-            if (invalidField?.input) {
-                showValidationError(validation.message, [invalidField.input]);
-                invalidField.input.focus();
-            }
-            return null;
+    fieldConfig.forEach(config => {
+        const normalizedField = validation.fieldResults?.[config.key];
+        if (normalizedField && typeof normalizedField.displayValue === "string") {
+            config.input.value = normalizedField.displayValue;
         }
+    });
 
-        return validation.draft;
+    if (!validation.isValid) {
+        const invalidField = fieldConfig.find(config => config.key === validation.invalidKey);
+        if (invalidField?.input) {
+            showValidationError(validation.message, [invalidField.input]);
+            invalidField.input.focus();
+        }
+        return null;
     }
 
-    const draft = {
-        soundEnabled: soundEnabledInput.checked
-    };
-
-    for (const { input, key, label, min, max, defaultValue } of fieldConfig) {
-        const normalizedField = normalizeMinuteInputValue(input, { key, label, min, max, defaultValue });
-        const value = normalizedField.value;
-
-        if (!normalizedField.isValid || !Number.isInteger(value) || value < min || value > max) {
-            showValidationError(`${label} must be between ${min} and ${max}.`, [input]);
-            input.focus();
-            return null;
-        }
-
-        draft[key] = value;
-    }
-
-    return timerStateStore ? timerStateStore.normalizeSettings(draft) : draft;
+    return validation.draft;
 }
 
 function openSettings() {
@@ -219,8 +156,8 @@ fieldConfig.forEach(({ input }) => {
     });
 });
 
-window.addEventListener("storage", (event) => {
-    if (!timerStateStore || event.key !== timerStateStore.keys.SETTINGS_KEY) return;
+window.addEventListener("storage", event => {
+    if (event.key !== timerStateStore.keys.SETTINGS_KEY) return;
 
     savedSettings = loadSettingsFromStorage();
     if (!settingsSection.classList.contains("hidden")) {
@@ -229,8 +166,6 @@ window.addEventListener("storage", (event) => {
     }
 });
 
-if (timerStateStore) {
-    savedSettings = loadSettingsFromStorage();
-    applySettingsToInputs(savedSettings);
-    document.dispatchEvent(new CustomEvent("settings:loaded", { detail: savedSettings }));
-}
+savedSettings = loadSettingsFromStorage();
+applySettingsToInputs(savedSettings);
+document.dispatchEvent(new CustomEvent("settings:loaded", { detail: savedSettings }));

--- a/js/sound.js
+++ b/js/sound.js
@@ -1,132 +1,130 @@
-(function (globalScope) {
-    const SILENT_WAV_DATA_URI = "data:audio/wav;base64,UklGRigAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQQAAAAA";
+const SILENT_WAV_DATA_URI = "data:audio/wav;base64,UklGRigAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQQAAAAA";
 
-    function createAudioElement(src, { muted = false, loop = false } = {}) {
-        const audio = new Audio(src);
-        audio.preload = "auto";
-        audio.muted = muted;
-        audio.loop = loop;
-        audio.playsInline = true;
-        return audio;
+function createAudioElement(src, { muted = false, loop = false } = {}) {
+    const audio = new Audio(src);
+    audio.preload = "auto";
+    audio.muted = muted;
+    audio.loop = loop;
+    audio.playsInline = true;
+    return audio;
+}
+
+function createSoundManager() {
+    const primingAudio = createAudioElement(SILENT_WAV_DATA_URI, { muted: true, loop: true });
+    const playbackAudio = createAudioElement(SILENT_WAV_DATA_URI, { muted: true, loop: true });
+    let isPrimed = false;
+
+    function emitSoundEvent(name, detail) {
+        if (typeof window?.CustomEvent !== "function") return;
+        window.dispatchEvent(new CustomEvent(name, { detail }));
     }
 
-    function createSoundManager() {
-        const primingAudio = createAudioElement(SILENT_WAV_DATA_URI, { muted: true, loop: true });
-        const playbackAudio = createAudioElement(SILENT_WAV_DATA_URI, { muted: true, loop: true });
-        let isPrimed = false;
-
-        function emitSoundEvent(name, detail) {
-            if (typeof globalScope.CustomEvent !== "function") return;
-            globalScope.dispatchEvent(new CustomEvent(name, { detail }));
+    async function startPrimingLoop() {
+        try {
+            await primingAudio.play();
+            isPrimed = true;
+        } catch {
+            isPrimed = false;
         }
+    }
 
-        async function startPrimingLoop() {
-            try {
-                await primingAudio.play();
-                isPrimed = true;
-            } catch (error) {
-                isPrimed = false;
-            }
+    async function unlockFromGesture() {
+        try {
+            await primingAudio.play();
+            await playbackAudio.play();
+            playbackAudio.pause();
+            playbackAudio.currentTime = 0;
+            playbackAudio.src = SILENT_WAV_DATA_URI;
+            playbackAudio.loop = true;
+            playbackAudio.muted = true;
+            await playbackAudio.play();
+            isPrimed = true;
+        } catch {
+            isPrimed = false;
         }
+    }
 
-        async function unlockFromGesture() {
+    function registerUnlockListeners() {
+        const unlockOnce = async () => {
+            await unlockFromGesture();
+            cleanup();
+        };
+
+        const cleanup = () => {
+            window.removeEventListener("pointerdown", unlockOnce, true);
+            window.removeEventListener("keydown", unlockOnce, true);
+            window.removeEventListener("touchstart", unlockOnce, true);
+        };
+
+        window.addEventListener("pointerdown", unlockOnce, true);
+        window.addEventListener("keydown", unlockOnce, true);
+        window.addEventListener("touchstart", unlockOnce, true);
+    }
+
+    async function play(fileName, enabled = true) {
+        if (!enabled) return false;
+
+        emitSoundEvent("pomodoro:sound-requested", { fileName });
+        const fileUrl = new URL(`../assets/sounds/${fileName}`, import.meta.url).href;
+
+        try {
+            playbackAudio.pause();
+            playbackAudio.currentTime = 0;
+            playbackAudio.loop = false;
+            playbackAudio.muted = false;
+            playbackAudio.src = fileUrl;
+            await playbackAudio.play();
+            isPrimed = true;
+            emitSoundEvent("pomodoro:sound-played", { fileName });
+            return true;
+        } catch {
             try {
-                await primingAudio.play();
+                await unlockFromGesture();
+                playbackAudio.pause();
+                playbackAudio.currentTime = 0;
+                playbackAudio.loop = false;
+                playbackAudio.muted = false;
+                playbackAudio.src = fileUrl;
                 await playbackAudio.play();
+                isPrimed = true;
+                emitSoundEvent("pomodoro:sound-played", { fileName });
+                return true;
+            } catch (retryError) {
+                emitSoundEvent("pomodoro:sound-blocked", { fileName });
+                console.warn("Sound playback was blocked on this page.", retryError);
+                return false;
+            }
+        } finally {
+            playbackAudio.addEventListener("ended", async function restoreLoop() {
+                playbackAudio.removeEventListener("ended", restoreLoop);
                 playbackAudio.pause();
                 playbackAudio.currentTime = 0;
                 playbackAudio.src = SILENT_WAV_DATA_URI;
                 playbackAudio.loop = true;
                 playbackAudio.muted = true;
-                await playbackAudio.play();
-                isPrimed = true;
-            } catch (error) {
-                isPrimed = false;
-            }
-        }
-
-        function registerUnlockListeners() {
-            const unlockOnce = async () => {
-                await unlockFromGesture();
-                cleanup();
-            };
-
-            const cleanup = () => {
-                globalScope.removeEventListener("pointerdown", unlockOnce, true);
-                globalScope.removeEventListener("keydown", unlockOnce, true);
-                globalScope.removeEventListener("touchstart", unlockOnce, true);
-            };
-
-            globalScope.addEventListener("pointerdown", unlockOnce, true);
-            globalScope.addEventListener("keydown", unlockOnce, true);
-            globalScope.addEventListener("touchstart", unlockOnce, true);
-        }
-
-        async function play(fileName, enabled = true) {
-            if (!enabled) return false;
-
-            emitSoundEvent("pomodoro:sound-requested", { fileName });
-
-            try {
-                playbackAudio.pause();
-                playbackAudio.currentTime = 0;
-                playbackAudio.loop = false;
-                playbackAudio.muted = false;
-                playbackAudio.src = `assets/sounds/${fileName}`;
-                await playbackAudio.play();
-                isPrimed = true;
-                return true;
-            } catch (error) {
                 try {
-                    await unlockFromGesture();
-                    playbackAudio.pause();
-                    playbackAudio.currentTime = 0;
-                    playbackAudio.loop = false;
-                    playbackAudio.muted = false;
-                    playbackAudio.src = `assets/sounds/${fileName}`;
                     await playbackAudio.play();
-                    isPrimed = true;
-                    emitSoundEvent("pomodoro:sound-played", { fileName });
-                    return true;
-                } catch (retryError) {
-                    emitSoundEvent("pomodoro:sound-blocked", { fileName });
-                    console.warn("Sound playback was blocked on this page.", retryError);
-                    return false;
+                } catch {
+                    isPrimed = false;
                 }
-            } finally {
-                playbackAudio.addEventListener("ended", async function restoreLoop() {
-                    playbackAudio.removeEventListener("ended", restoreLoop);
-                    playbackAudio.pause();
-                    playbackAudio.currentTime = 0;
-                    playbackAudio.src = SILENT_WAV_DATA_URI;
-                    playbackAudio.loop = true;
-                    playbackAudio.muted = true;
-                    try {
-                        await playbackAudio.play();
-                    } catch (error) {
-                        isPrimed = false;
-                    }
-                }, { once: true });
-            }
+            }, { once: true });
         }
-
-        startPrimingLoop();
-        registerUnlockListeners();
-
-        return {
-            play,
-            unlockFromGesture,
-            isPrimed: () => isPrimed
-        };
     }
 
-    const manager = createSoundManager();
+    startPrimingLoop();
+    registerUnlockListeners();
 
-    if (globalScope) {
-        globalScope.PomodoroSoundManager = manager;
-    }
+    return {
+        play,
+        unlockFromGesture,
+        isPrimed: () => isPrimed
+    };
+}
 
-    if (typeof module !== "undefined" && module.exports) {
-        module.exports = manager;
-    }
-})(typeof window !== "undefined" ? window : globalThis);
+const manager = createSoundManager();
+
+if (typeof window !== "undefined") {
+    window.PomodoroSoundManager = manager;
+}
+
+export default manager;

--- a/js/timer-state.js
+++ b/js/timer-state.js
@@ -1,347 +1,344 @@
-(function (globalScope) {
-    const SETTINGS_KEY = "pomodoroSettings";
-    const TIMER_STATE_KEY = "pomodoroTimerState";
-    const POMODOROS_PER_CYCLE = 4;
-    const VALID_MODES = ["pomodoro", "short-break", "long-break"];
+const SETTINGS_KEY = "pomodoroSettings";
+const TIMER_STATE_KEY = "pomodoroTimerState";
+const POMODOROS_PER_CYCLE = 4;
+const VALID_MODES = ["pomodoro", "short-break", "long-break"];
 
-    const DEFAULT_SETTINGS = {
-        pomodoro: 25,
-        shortBreak: 5,
-        longBreak: 15,
-        soundEnabled: true
+const DEFAULT_SETTINGS = {
+    pomodoro: 25,
+    shortBreak: 5,
+    longBreak: 15,
+    soundEnabled: true
+};
+
+const SETTINGS_LIMITS = {
+    pomodoro: 120,
+    shortBreak: 30,
+    longBreak: 80
+};
+
+function toPositiveInteger(value, fallback, min = 1, max = Number.POSITIVE_INFINITY) {
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isFinite(parsed) || parsed < min) {
+        return fallback;
+    }
+
+    return Math.min(parsed, max);
+}
+
+function normalizeSettings(settings = {}) {
+    return {
+        pomodoro: toPositiveInteger(settings.pomodoro, DEFAULT_SETTINGS.pomodoro, 1, SETTINGS_LIMITS.pomodoro),
+        shortBreak: toPositiveInteger(settings.shortBreak, DEFAULT_SETTINGS.shortBreak, 1, SETTINGS_LIMITS.shortBreak),
+        longBreak: toPositiveInteger(settings.longBreak, DEFAULT_SETTINGS.longBreak, 1, SETTINGS_LIMITS.longBreak),
+        soundEnabled: settings.soundEnabled !== false
     };
-    const SETTINGS_LIMITS = {
-        pomodoro: 120,
-        shortBreak: 30,
-        longBreak: 80
+}
+
+function getSettingsKey(mode) {
+    if (mode === "pomodoro") return "pomodoro";
+    if (mode === "short-break") return "shortBreak";
+    if (mode === "long-break") return "longBreak";
+    return "pomodoro";
+}
+
+function getModeDurationSeconds(settings, mode) {
+    const safeSettings = normalizeSettings(settings);
+    return safeSettings[getSettingsKey(mode)] * 60;
+}
+
+function getDefaultTimerState(settings) {
+    const safeSettings = normalizeSettings(settings);
+
+    return {
+        currentMode: "pomodoro",
+        isRunning: false,
+        endTime: null,
+        remainingSeconds: getModeDurationSeconds(safeSettings, "pomodoro"),
+        completedPomodorosInCycle: 0
     };
+}
 
-    function toPositiveInteger(value, fallback, min = 1, max = Number.POSITIVE_INFINITY) {
-        const parsed = Number.parseInt(value, 10);
-        if (!Number.isFinite(parsed) || parsed < min) {
-            return fallback;
-        }
+function normalizeTimerState(state = {}, settings) {
+    const safeSettings = normalizeSettings(settings);
+    const fallback = getDefaultTimerState(safeSettings);
+    const currentMode = VALID_MODES.includes(state.currentMode) ? state.currentMode : fallback.currentMode;
+    const remainingFallback = getModeDurationSeconds(safeSettings, currentMode);
+    const rawRemainingSeconds = Number.parseInt(state.remainingSeconds, 10);
+    const remainingSeconds = Number.isFinite(rawRemainingSeconds) && rawRemainingSeconds >= 0
+        ? rawRemainingSeconds
+        : remainingFallback;
+    const completedPomodorosInCycle = Math.min(
+        toPositiveInteger(state.completedPomodorosInCycle, 0, 0, POMODOROS_PER_CYCLE),
+        POMODOROS_PER_CYCLE
+    );
+    const isRunning = Boolean(state.isRunning);
+    const rawEndTime = Number(state.endTime);
+    const endTime = isRunning && Number.isFinite(rawEndTime) ? rawEndTime : null;
 
-        return Math.min(parsed, max);
+    return {
+        currentMode,
+        isRunning,
+        endTime,
+        remainingSeconds,
+        completedPomodorosInCycle
+    };
+}
+
+function cloneState(state) {
+    return {
+        currentMode: state.currentMode,
+        isRunning: state.isRunning,
+        endTime: state.endTime,
+        remainingSeconds: state.remainingSeconds,
+        completedPomodorosInCycle: state.completedPomodorosInCycle
+    };
+}
+
+function loadSettings() {
+    const saved = localStorage.getItem(SETTINGS_KEY);
+    if (!saved) {
+        return normalizeSettings();
     }
 
-    function normalizeSettings(settings = {}) {
-        return {
-            pomodoro: toPositiveInteger(settings.pomodoro, DEFAULT_SETTINGS.pomodoro, 1, SETTINGS_LIMITS.pomodoro),
-            shortBreak: toPositiveInteger(settings.shortBreak, DEFAULT_SETTINGS.shortBreak, 1, SETTINGS_LIMITS.shortBreak),
-            longBreak: toPositiveInteger(settings.longBreak, DEFAULT_SETTINGS.longBreak, 1, SETTINGS_LIMITS.longBreak),
-            soundEnabled: settings.soundEnabled !== false
-        };
+    try {
+        return normalizeSettings(JSON.parse(saved));
+    } catch (error) {
+        console.warn("Failed to parse saved settings.", error);
+        return normalizeSettings();
+    }
+}
+
+function saveSettings(settings) {
+    const normalized = normalizeSettings(settings);
+    localStorage.setItem(SETTINGS_KEY, JSON.stringify(normalized));
+    return normalized;
+}
+
+function getRemainingSeconds(state, now = Date.now()) {
+    if (!state.isRunning || !state.endTime) {
+        return Math.max(0, state.remainingSeconds);
     }
 
-    function getSettingsKey(mode) {
-        if (mode === "pomodoro") return "pomodoro";
-        if (mode === "short-break") return "shortBreak";
-        if (mode === "long-break") return "longBreak";
-        return "pomodoro";
-    }
+    return Math.max(0, Math.ceil((state.endTime - now) / 1000));
+}
 
-    function getModeDurationSeconds(settings, mode) {
-        const safeSettings = normalizeSettings(settings);
-        return safeSettings[getSettingsKey(mode)] * 60;
-    }
-
-    function getDefaultTimerState(settings) {
-        const safeSettings = normalizeSettings(settings);
-
-        return {
-            currentMode: "pomodoro",
-            isRunning: false,
-            endTime: null,
-            remainingSeconds: getModeDurationSeconds(safeSettings, "pomodoro"),
-            completedPomodorosInCycle: 0
-        };
-    }
-
-    function normalizeTimerState(state = {}, settings) {
-        const safeSettings = normalizeSettings(settings);
-        const fallback = getDefaultTimerState(safeSettings);
-        const currentMode = VALID_MODES.includes(state.currentMode) ? state.currentMode : fallback.currentMode;
-        const remainingFallback = getModeDurationSeconds(safeSettings, currentMode);
-        const rawRemainingSeconds = Number.parseInt(state.remainingSeconds, 10);
-        const remainingSeconds = Number.isFinite(rawRemainingSeconds) && rawRemainingSeconds >= 0
-            ? rawRemainingSeconds
-            : remainingFallback;
+function transitionAfterCompletion(state, settings, completedAt) {
+    if (state.currentMode === "pomodoro") {
         const completedPomodorosInCycle = Math.min(
-            toPositiveInteger(state.completedPomodorosInCycle, 0, 0, POMODOROS_PER_CYCLE),
+            state.completedPomodorosInCycle + 1,
             POMODOROS_PER_CYCLE
         );
-        const isRunning = Boolean(state.isRunning);
-        const rawEndTime = Number(state.endTime);
-        const endTime = isRunning && Number.isFinite(rawEndTime) ? rawEndTime : null;
+        const nextMode = completedPomodorosInCycle >= POMODOROS_PER_CYCLE
+            ? "long-break"
+            : "short-break";
+        const remainingSeconds = getModeDurationSeconds(settings, nextMode);
 
         return {
-            currentMode,
-            isRunning,
-            endTime,
+            currentMode: nextMode,
+            isRunning: true,
+            endTime: completedAt + (remainingSeconds * 1000),
             remainingSeconds,
             completedPomodorosInCycle
         };
     }
 
-    function cloneState(state) {
+    if (state.currentMode === "short-break") {
+        const remainingSeconds = getModeDurationSeconds(settings, "pomodoro");
+
         return {
-            currentMode: state.currentMode,
-            isRunning: state.isRunning,
-            endTime: state.endTime,
-            remainingSeconds: state.remainingSeconds,
+            currentMode: "pomodoro",
+            isRunning: true,
+            endTime: completedAt + (remainingSeconds * 1000),
+            remainingSeconds,
             completedPomodorosInCycle: state.completedPomodorosInCycle
         };
     }
 
-    function loadSettings() {
-        const saved = localStorage.getItem(SETTINGS_KEY);
-        if (!saved) {
-            return normalizeSettings();
-        }
-
-        try {
-            return normalizeSettings(JSON.parse(saved));
-        } catch (error) {
-            console.warn("Failed to parse saved settings.", error);
-            return normalizeSettings();
-        }
-    }
-
-    function saveSettings(settings) {
-        const normalized = normalizeSettings(settings);
-        localStorage.setItem(SETTINGS_KEY, JSON.stringify(normalized));
-        return normalized;
-    }
-
-    function getRemainingSeconds(state, now = Date.now()) {
-        if (!state.isRunning || !state.endTime) {
-            return Math.max(0, state.remainingSeconds);
-        }
-
-        return Math.max(0, Math.ceil((state.endTime - now) / 1000));
-    }
-
-    function transitionAfterCompletion(state, settings, completedAt) {
-        if (state.currentMode === "pomodoro") {
-            const completedPomodorosInCycle = Math.min(
-                state.completedPomodorosInCycle + 1,
-                POMODOROS_PER_CYCLE
-            );
-            const nextMode = completedPomodorosInCycle >= POMODOROS_PER_CYCLE
-                ? "long-break"
-                : "short-break";
-            const remainingSeconds = getModeDurationSeconds(settings, nextMode);
-
-            return {
-                currentMode: nextMode,
-                isRunning: true,
-                endTime: completedAt + (remainingSeconds * 1000),
-                remainingSeconds,
-                completedPomodorosInCycle
-            };
-        }
-
-        if (state.currentMode === "short-break") {
-            const remainingSeconds = getModeDurationSeconds(settings, "pomodoro");
-
-            return {
-                currentMode: "pomodoro",
-                isRunning: true,
-                endTime: completedAt + (remainingSeconds * 1000),
-                remainingSeconds,
-                completedPomodorosInCycle: state.completedPomodorosInCycle
-            };
-        }
-
-        if (state.currentMode === "long-break") {
-            return getDefaultTimerState(settings);
-        }
-
+    if (state.currentMode === "long-break") {
         return getDefaultTimerState(settings);
     }
 
-    function hydrateTimerState(state, settings, now = Date.now()) {
-        const safeSettings = normalizeSettings(settings);
-        let nextState = normalizeTimerState(state, safeSettings);
+    return getDefaultTimerState(settings);
+}
 
-        if (!nextState.isRunning) {
-            nextState.remainingSeconds = Math.max(0, nextState.remainingSeconds);
-            nextState.endTime = null;
-            return nextState;
-        }
+function hydrateTimerState(state, settings, now = Date.now()) {
+    const safeSettings = normalizeSettings(settings);
+    let nextState = normalizeTimerState(state, safeSettings);
 
-        let guard = 0;
-        while (nextState.isRunning && nextState.endTime && nextState.endTime <= now && guard < 100) {
-            nextState = transitionAfterCompletion(nextState, safeSettings, nextState.endTime);
-            guard += 1;
-        }
-
-        nextState.remainingSeconds = getRemainingSeconds(nextState, now);
+    if (!nextState.isRunning) {
+        nextState.remainingSeconds = Math.max(0, nextState.remainingSeconds);
+        nextState.endTime = null;
         return nextState;
     }
 
-    function loadTimerState(settings) {
-        const safeSettings = normalizeSettings(settings);
-        const saved = localStorage.getItem(TIMER_STATE_KEY);
-
-        if (!saved) {
-            return getDefaultTimerState(safeSettings);
-        }
-
-        try {
-            return hydrateTimerState(JSON.parse(saved), safeSettings, Date.now());
-        } catch (error) {
-            console.warn("Failed to parse saved timer state.", error);
-            return getDefaultTimerState(safeSettings);
-        }
+    let guard = 0;
+    while (nextState.isRunning && nextState.endTime && nextState.endTime <= now && guard < 100) {
+        nextState = transitionAfterCompletion(nextState, safeSettings, nextState.endTime);
+        guard += 1;
     }
 
-    function saveTimerState(state, settings) {
-        const normalized = normalizeTimerState(state, settings || loadSettings());
-        localStorage.setItem(TIMER_STATE_KEY, JSON.stringify(normalized));
-        return normalized;
-    }
+    nextState.remainingSeconds = getRemainingSeconds(nextState, now);
+    return nextState;
+}
 
-    function startTimerState(state, settings, now = Date.now()) {
-        const safeSettings = normalizeSettings(settings);
-        const syncedState = hydrateTimerState(state, safeSettings, now);
+function loadTimerState(settings) {
+    const safeSettings = normalizeSettings(settings);
+    const saved = localStorage.getItem(TIMER_STATE_KEY);
 
-        if (syncedState.isRunning) {
-            return syncedState;
-        }
-
-        const remainingSeconds = syncedState.remainingSeconds > 0
-            ? syncedState.remainingSeconds
-            : getModeDurationSeconds(safeSettings, syncedState.currentMode);
-
-        return {
-            ...cloneState(syncedState),
-            isRunning: true,
-            endTime: now + (remainingSeconds * 1000),
-            remainingSeconds
-        };
-    }
-
-    function pauseTimerState(state, settings, now = Date.now()) {
-        const safeSettings = normalizeSettings(settings);
-        const syncedState = hydrateTimerState(state, safeSettings, now);
-
-        if (!syncedState.isRunning) {
-            return {
-                ...cloneState(syncedState),
-                endTime: null
-            };
-        }
-
-        return {
-            ...cloneState(syncedState),
-            isRunning: false,
-            endTime: null,
-            remainingSeconds: getRemainingSeconds(syncedState, now)
-        };
-    }
-
-    function resetTimerState(state, settings) {
-        const safeSettings = settings ? normalizeSettings(settings) : loadSettings();
+    if (!saved) {
         return getDefaultTimerState(safeSettings);
     }
 
-    function applySettingsToTimerState(state, settings) {
-        const safeSettings = normalizeSettings(settings);
-        const syncedState = hydrateTimerState(state, safeSettings, Date.now());
+    try {
+        return hydrateTimerState(JSON.parse(saved), safeSettings, Date.now());
+    } catch (error) {
+        console.warn("Failed to parse saved timer state.", error);
+        return getDefaultTimerState(safeSettings);
+    }
+}
 
-        if (syncedState.isRunning) {
-            return syncedState;
-        }
+function saveTimerState(state, settings) {
+    const normalized = normalizeTimerState(state, settings || loadSettings());
+    localStorage.setItem(TIMER_STATE_KEY, JSON.stringify(normalized));
+    return normalized;
+}
 
+function startTimerState(state, settings, now = Date.now()) {
+    const safeSettings = normalizeSettings(settings);
+    const syncedState = hydrateTimerState(state, safeSettings, now);
+
+    if (syncedState.isRunning) {
+        return syncedState;
+    }
+
+    const remainingSeconds = syncedState.remainingSeconds > 0
+        ? syncedState.remainingSeconds
+        : getModeDurationSeconds(safeSettings, syncedState.currentMode);
+
+    return {
+        ...cloneState(syncedState),
+        isRunning: true,
+        endTime: now + (remainingSeconds * 1000),
+        remainingSeconds
+    };
+}
+
+function pauseTimerState(state, settings, now = Date.now()) {
+    const safeSettings = normalizeSettings(settings);
+    const syncedState = hydrateTimerState(state, safeSettings, now);
+
+    if (!syncedState.isRunning) {
         return {
             ...cloneState(syncedState),
-            remainingSeconds: getModeDurationSeconds(safeSettings, syncedState.currentMode),
             endTime: null
         };
     }
 
-    function getCurrentPomodoroNumber(state) {
-        const completedPomodorosInCycle = Math.min(
-            toPositiveInteger(state.completedPomodorosInCycle, 0, 0, POMODOROS_PER_CYCLE),
-            POMODOROS_PER_CYCLE
-        );
-
-        if (state.currentMode === "pomodoro") {
-            return Math.min(completedPomodorosInCycle + 1, POMODOROS_PER_CYCLE);
-        }
-
-        return Math.max(1, completedPomodorosInCycle);
-    }
-
-    function getProjectedCycleEndTime(state, settings, now = Date.now()) {
-        const safeSettings = normalizeSettings(settings);
-        let simulatedState = hydrateTimerState(state, safeSettings, now);
-
-        if (!simulatedState.isRunning) {
-            simulatedState = startTimerState(simulatedState, safeSettings, now);
-        }
-
-        let guard = 0;
-        while (guard < 100) {
-            if (!simulatedState.isRunning || !simulatedState.endTime) {
-                return null;
-            }
-
-            const segmentEndTime = simulatedState.endTime;
-            const nextState = transitionAfterCompletion(simulatedState, safeSettings, segmentEndTime);
-            if (!nextState.isRunning) {
-                return segmentEndTime;
-            }
-
-            simulatedState = nextState;
-            guard += 1;
-        }
-
-        return null;
-    }
-
-    function areStatesEqual(firstState, secondState) {
-        return firstState.currentMode === secondState.currentMode
-            && firstState.isRunning === secondState.isRunning
-            && firstState.endTime === secondState.endTime
-            && firstState.remainingSeconds === secondState.remainingSeconds
-            && firstState.completedPomodorosInCycle === secondState.completedPomodorosInCycle;
-    }
-
-    const api = {
-        keys: {
-            SETTINGS_KEY,
-            TIMER_STATE_KEY
-        },
-        normalizeSettings,
-        getDefaultSettings: () => normalizeSettings(),
-        getSettingsKey,
-        getModeDurationSeconds,
-        getDefaultTimerState,
-        normalizeTimerState,
-        loadSettings,
-        saveSettings,
-        loadTimerState,
-        saveTimerState,
-        hydrateTimerState,
-        startTimerState,
-        pauseTimerState,
-        resetTimerState,
-        applySettingsToTimerState,
-        getRemainingSeconds,
-        getCurrentPomodoroNumber,
-        getProjectedCycleEndTime,
-        getPomodorosPerCycle: () => POMODOROS_PER_CYCLE,
-        areStatesEqual
+    return {
+        ...cloneState(syncedState),
+        isRunning: false,
+        endTime: null,
+        remainingSeconds: getRemainingSeconds(syncedState, now)
     };
+}
 
-    if (globalScope) {
-        globalScope.PomodoroTimerState = api;
+function resetTimerState(state, settings) {
+    const safeSettings = settings ? normalizeSettings(settings) : loadSettings();
+    return getDefaultTimerState(safeSettings);
+}
+
+function applySettingsToTimerState(state, settings) {
+    const safeSettings = normalizeSettings(settings);
+    const syncedState = hydrateTimerState(state, safeSettings, Date.now());
+
+    if (syncedState.isRunning) {
+        return syncedState;
     }
 
-    if (typeof module !== "undefined" && module.exports) {
-        module.exports = api;
+    return {
+        ...cloneState(syncedState),
+        remainingSeconds: getModeDurationSeconds(safeSettings, syncedState.currentMode),
+        endTime: null
+    };
+}
+
+function getCurrentPomodoroNumber(state) {
+    const completedPomodorosInCycle = Math.min(
+        toPositiveInteger(state.completedPomodorosInCycle, 0, 0, POMODOROS_PER_CYCLE),
+        POMODOROS_PER_CYCLE
+    );
+
+    if (state.currentMode === "pomodoro") {
+        return Math.min(completedPomodorosInCycle + 1, POMODOROS_PER_CYCLE);
     }
-})(typeof window !== "undefined" ? window : globalThis);
+
+    return Math.max(1, completedPomodorosInCycle);
+}
+
+function getProjectedCycleEndTime(state, settings, now = Date.now()) {
+    const safeSettings = normalizeSettings(settings);
+    let simulatedState = hydrateTimerState(state, safeSettings, now);
+
+    if (!simulatedState.isRunning) {
+        simulatedState = startTimerState(simulatedState, safeSettings, now);
+    }
+
+    let guard = 0;
+    while (guard < 100) {
+        if (!simulatedState.isRunning || !simulatedState.endTime) {
+            return null;
+        }
+
+        const segmentEndTime = simulatedState.endTime;
+        const nextState = transitionAfterCompletion(simulatedState, safeSettings, segmentEndTime);
+        if (!nextState.isRunning) {
+            return segmentEndTime;
+        }
+
+        simulatedState = nextState;
+        guard += 1;
+    }
+
+    return null;
+}
+
+function areStatesEqual(firstState, secondState) {
+    return firstState.currentMode === secondState.currentMode
+        && firstState.isRunning === secondState.isRunning
+        && firstState.endTime === secondState.endTime
+        && firstState.remainingSeconds === secondState.remainingSeconds
+        && firstState.completedPomodorosInCycle === secondState.completedPomodorosInCycle;
+}
+
+const api = {
+    keys: {
+        SETTINGS_KEY,
+        TIMER_STATE_KEY
+    },
+    normalizeSettings,
+    getDefaultSettings: () => normalizeSettings(),
+    getSettingsKey,
+    getModeDurationSeconds,
+    getDefaultTimerState,
+    normalizeTimerState,
+    loadSettings,
+    saveSettings,
+    loadTimerState,
+    saveTimerState,
+    hydrateTimerState,
+    startTimerState,
+    pauseTimerState,
+    resetTimerState,
+    applySettingsToTimerState,
+    getRemainingSeconds,
+    getCurrentPomodoroNumber,
+    getProjectedCycleEndTime,
+    getPomodorosPerCycle: () => POMODOROS_PER_CYCLE,
+    areStatesEqual
+};
+
+if (typeof window !== "undefined") {
+    window.PomodoroTimerState = api;
+}
+
+export default api;

--- a/js/timer.js
+++ b/js/timer.js
@@ -1,6 +1,7 @@
+import timerStateStore from "./timer-state.js";
+import soundManager from "./sound.js";
+
 document.addEventListener("DOMContentLoaded", () => {
-    const timerStateStore = window.PomodoroTimerState;
-    const soundManager = window.PomodoroSoundManager;
     const timeDisplay = document.getElementById("timeDisplay");
     const startBtn = document.getElementById("startBtn");
     const resetBtn = document.getElementById("resetBtn");
@@ -13,7 +14,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const modeLabels = document.querySelectorAll(".mode-label");
     const settingsToggle = document.getElementById("settingsToggle");
 
-    if (!timerStateStore || !timeDisplay || !startBtn || !resetBtn || !timerLabel || !progressBar) return;
+    if (!timeDisplay || !startBtn || !resetBtn || !timerLabel || !progressBar) return;
 
     const labelText = {
         pomodoro: "Focus Time",
@@ -28,9 +29,9 @@ document.addEventListener("DOMContentLoaded", () => {
     let timerWorker = null;
     let lastWorkerRunningState = null;
     try {
-        timerWorker = new Worker("js/worker.js");
-    } catch (error) {
-        console.warn("Web Workers require a server context (e.g., Live Server) to function.");
+        timerWorker = new Worker(new URL("./worker.js", import.meta.url), { type: "module" });
+    } catch {
+        console.warn("Web Workers require a server context (e.g., Vite dev server) to function.");
     }
 
     let settings = timerStateStore.loadSettings();
@@ -47,7 +48,7 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     function playSound(fileName) {
-        soundManager?.play(fileName, settings.soundEnabled);
+        soundManager.play(fileName, settings.soundEnabled);
     }
 
     function setWorkerState(shouldRun) {
@@ -175,7 +176,7 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     if (timerWorker) {
-        timerWorker.onmessage = (event) => {
+        timerWorker.onmessage = event => {
             if (event.data === "tick") {
                 onTimerTick();
             }
@@ -211,14 +212,14 @@ document.addEventListener("DOMContentLoaded", () => {
         render();
     });
 
-    document.addEventListener("settings:updated", (event) => {
+    document.addEventListener("settings:updated", event => {
         settings = event.detail;
         timerState = timerStateStore.applySettingsToTimerState(timerState, settings);
         persistTimerState();
         render();
     });
 
-    window.addEventListener("storage", (event) => {
+    window.addEventListener("storage", event => {
         if (event.key === timerStateStore.keys.SETTINGS_KEY) {
             settings = timerStateStore.loadSettings();
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,13 @@
       "name": "pomodoro-weblabs",
       "version": "1.0.0",
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@playwright/test": "^1.59.1",
+        "eslint": "^10.2.0",
+        "globals": "^17.4.0",
         "jsdom": "^26.1.0",
+        "prettier": "^3.8.1",
+        "vite": "^7.3.2",
         "vitest": "^3.2.4"
       }
     },
@@ -584,6 +589,186 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
+      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -1014,10 +1199,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1136,6 +1335,29 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -1146,6 +1368,23 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1154,6 +1393,29 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/cac": {
@@ -1191,6 +1453,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/cssstyle": {
@@ -1256,6 +1533,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/entities": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -1318,6 +1602,161 @@
         "@esbuild/win32-x64": "0.27.7"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.0.tgz",
+      "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.4",
+        "@eslint/config-helpers": "^0.5.4",
+        "@eslint/core": "^1.2.0",
+        "@eslint/plugin-kit": "^0.7.0",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1326,6 +1765,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/expect-type": {
@@ -1337,6 +1786,27 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1356,6 +1826,57 @@
         }
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -1369,6 +1890,32 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
+      "integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -1425,12 +1972,62 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/js-tokens": {
       "version": "9.0.1",
@@ -1479,6 +2076,67 @@
         }
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -1501,6 +2159,22 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ms": {
@@ -1529,12 +2203,69 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nwsapi": {
       "version": "2.2.23",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
       "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/parse5": {
       "version": "7.3.0",
@@ -1547,6 +2278,26 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pathe": {
@@ -1647,6 +2398,32 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -1727,6 +2504,29 @@
       },
       "engines": {
         "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/siginfo": {
@@ -1885,6 +2685,29 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/vite": {
@@ -2134,6 +2957,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -2149,6 +2988,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ws": {
@@ -2189,6 +3038,19 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint .",
     "start:test-server": "node tests/server.js",
     "test": "npm run test:unit && npm run test:e2e",
     "test:unit": "vitest run",
@@ -17,8 +21,13 @@
     "test:regression:quiet": "TEST_EXPLANATIONS=0 playwright test -c playwright.regression.config.js"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.59.1",
+    "eslint": "^10.2.0",
+    "globals": "^17.4.0",
     "jsdom": "^26.1.0",
+    "prettier": "^3.8.1",
+    "vite": "^7.3.2",
     "vitest": "^3.2.4"
   }
 }

--- a/productivity.html
+++ b/productivity.html
@@ -149,14 +149,10 @@
                 &copy; 2026 Pomodoro Web |
                 <a href="https://github.com/docholypancake/pomodoroWeb/issues" class="footer-link">GitHub</a>
             </p>
-            <p class="footer-note">Stay focused, stay productive</p>
+            <p class="footer-note">Stay focused, stay productive | Mode: <span data-app-status>Unknown</span></p>
         </div>
     </footer>
 
-    <script src="js/sound.js"></script>
-    <script src="js/timer-state.js"></script>
-    <script src="js/mini-timer.js"></script>
-    <script src="js/productivity-store.js"></script>
-    <script src="js/productivity.js"></script>
+    <script type="module" src="js/entries/productivity-page.js"></script>
 </body>
 </html>

--- a/tests/e2e/smoke.spec.js
+++ b/tests/e2e/smoke.spec.js
@@ -74,6 +74,7 @@ test.describe("smoke coverage", () => {
         await expect(page.locator("#todoInput")).toBeVisible();
         await expect(page.locator("#noteInput")).toBeHidden();
         await page.click('[data-tab-trigger="notes"]');
-        await expect(page.locator("#noteInput")).toBeVisible();
+        await expect(page.locator('#productivity-panel-notes')).not.toHaveClass(/hidden/);
+        await expect(page.locator('#productivity-panel-notes')).toHaveAttribute("aria-hidden", "false");
     });
 });

--- a/tests/server.js
+++ b/tests/server.js
@@ -27,7 +27,7 @@ function resolveRequestPath(requestUrl) {
 
     try {
         cleanPath = decodeURIComponent((requestUrl || "/").split("?")[0]);
-    } catch (error) {
+    } catch {
         return { errorStatusCode: 400, absolutePath: null };
     }
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,17 @@
+const { resolve } = require("path");
+const { defineConfig } = require("vite");
+
+module.exports = defineConfig({
+    build: {
+        sourcemap: true,
+        outDir: "dist",
+        rollupOptions: {
+            input: {
+                main: resolve(__dirname, "index.html"),
+                productivity: resolve(__dirname, "productivity.html"),
+                about: resolve(__dirname, "about.html"),
+                helpus: resolve(__dirname, "helpus.html")
+            }
+        }
+    }
+});


### PR DESCRIPTION
Convert the app to ES module entry points and modernize code structure: add entry modules (js/entries/*) and app-status to surface VITE_APP_STATUS in the UI; update HTML pages to use module scripts and show the app mode. Introduce project tooling/config: eslint.config.js, .prettierrc, .prettierignore, .env.production and vite.config.js; add dist to .gitignore. Refactor core JS into modular exports and improved logic: rewrite productivity-store, settings-validation, settings, sound, timer-state, and mini-timer to use imports/exports, stronger validation/normalization, safer storage handling, and more robust sound playback/priming. Preserve window compatibility by attaching API objects where needed. Also update package.json and tests to align with these changes.