### PR TITLE
Enable manual dispatch for CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
       - dev
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
Add workflow_dispatch trigger to .github/workflows/ci.yml so the CI workflow can be run manually from the GitHub UI. Existing branch triggers (main, dev) and the concurrency group remain unchanged.