### PR TITLE
Add CI badge and adjust workflow for Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI/CD Pipeline
 
 on:
   push:
@@ -84,7 +84,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: e2e
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -95,6 +94,7 @@ jobs:
       - run: npm run build
 
       - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v3
         with:
           path: dist

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
+[![CI/CD Pipeline](https://github.com/docholypancake/pomodoroWeb/actions/workflows/ci.yml/badge.svg)](https://github.com/docholypancake/pomodoroWeb/actions/workflows/ci.yml)
+
 # Pomodoro Web
 
 Pomodoro Web is a static browser-based focus app with a persistent 4-session Pomodoro timer, a mini timer for secondary pages, and a local-only productivity workspace for tasks and notes.
+
+Production: [docholypancake.github.io/pomodoroWeb](https://docholypancake.github.io/pomodoroWeb/)
 
 ## Product Overview
 - Persistent Pomodoro cycle that survives refreshes, tab switches, and browser restarts by rehydrating state from `localStorage`


### PR DESCRIPTION
Rename GitHub Actions workflow to "CI/CD Pipeline" and move the main-branch restriction from the build job to the Pages upload step so the build runs for more events while the artifact upload only occurs on pushes to main. Also add a workflow status badge and a Production site link to the README.